### PR TITLE
feat: pass seekTo position from native to Dart

### DIFF
--- a/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionPlugin.kt
+++ b/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionPlugin.kt
@@ -102,11 +102,15 @@ class FlutterMediaSessionPlugin: FlutterPlugin, MethodCallHandler {
     /**
      * Sends a media action event back to the Flutter side.
      * @param action The name of the action (e.g., "play", "pause").
-     * @param args Optional arguments for the action (e.g., seek position).
+     * @param args Optional arguments for the action (e.g., seek position in ms).
      */
     fun sendAction(action: String, args: Any? = null) {
         android.os.Handler(android.os.Looper.getMainLooper()).post {
-            eventSink?.success(action)
+            if (args != null) {
+                eventSink?.success(mapOf("action" to action, "args" to args))
+            } else {
+                eventSink?.success(action)
+            }
         }
     }
 

--- a/lib/flutter_media_session_method_channel.dart
+++ b/lib/flutter_media_session_method_channel.dart
@@ -37,6 +37,17 @@ class MethodChannelFlutterMediaSession extends FlutterMediaSessionPlatform {
   @override
   Stream<MediaAction> get onMediaAction {
     return eventChannel.receiveBroadcastStream().map((event) {
+      if (event is Map) {
+        final action = event['action'] as String;
+        final args = event['args'];
+        if (action == 'seekTo' && args is num) {
+          return MediaAction(
+            action,
+            seekPosition: Duration(milliseconds: args.toInt()),
+          );
+        }
+        return MediaAction(action);
+      }
       return MediaAction(event as String);
     });
   }

--- a/lib/flutter_media_session_web.dart
+++ b/lib/flutter_media_session_web.dart
@@ -124,7 +124,19 @@ class FlutterMediaSessionWeb extends FlutterMediaSessionPlatform {
       session.setActionHandler(
           actionName,
           ((JSAny? details) {
-            // Todo: For 'seekto', extract the seek position from details if needed.
+            if (actionName == 'seekto' && details != null) {
+              // Extract seekTime from the MediaSessionActionDetails object.
+              final map = (details as JSObject);
+              final seekTime = (map['seekTime'] as JSNumber?)?.toDartDouble;
+              if (seekTime != null) {
+                _actionController.add(MediaAction(
+                  'seekTo',
+                  seekPosition:
+                      Duration(milliseconds: (seekTime * 1000).round()),
+                ));
+                return;
+              }
+            }
             _actionController.add(actionToEmit);
           }).toJS);
     } catch (e) {

--- a/lib/src/models/media_action.dart
+++ b/lib/src/models/media_action.dart
@@ -3,8 +3,12 @@ class MediaAction {
   /// The unique name of the action.
   final String name;
 
-  /// Creates a new [MediaAction] instance with the given [name].
-  const MediaAction(this.name);
+  /// Optional seek position in milliseconds (only set for [seekTo] actions).
+  final Duration? seekPosition;
+
+  /// Creates a new [MediaAction] instance with the given [name] and optional
+  /// [seekPosition].
+  const MediaAction(this.name, {this.seekPosition});
 
   /// Action to resume playback.
   static const play = MediaAction('play');
@@ -22,6 +26,10 @@ class MediaAction {
   static const stop = MediaAction('stop');
 
   /// Action to seek to a specific position.
+  ///
+  /// When received from system controls, [seekPosition] contains the target
+  /// position. Use [MediaAction.seekTo] as a constant only for equality checks;
+  /// actual seek events will have a non-null [seekPosition].
   static const seekTo = MediaAction('seekTo');
 
   /// Action to rewind playback by a standard interval.
@@ -41,5 +49,6 @@ class MediaAction {
   int get hashCode => name.hashCode;
 
   @override
-  String toString() => name;
+  String toString() =>
+      seekPosition != null ? '$name(${seekPosition!.inMilliseconds}ms)' : name;
 }


### PR DESCRIPTION
## Summary
`MediaAction.seekTo` events from system media controls now include the target position, enabling apps to know *where* the user seeked to — not just that a seek happened.

### Changes
- **`MediaAction`**: Added optional `seekPosition` field (`Duration?`)
- **Android**: `sendAction()` sends a map `{action, args}` when args are present (backwards-compatible — simple actions still send plain strings)
- **Dart method channel**: Parses both string and map events, extracts `seekPosition` for seekTo actions
- **Web**: Extracts `seekTime` from `MediaSessionActionDetails` for the `seekto` handler

### Usage
```dart
_mediaSession.onMediaAction.listen((action) {
  if (action == MediaAction.seekTo && action.seekPosition != null) {
    myPlayer.seek(action.seekPosition!);
  }
});
```

### Backwards Compatibility
- Existing code using `action == MediaAction.seekTo` still works
- `seekPosition` is nullable — callers that don't need it can ignore it
- Android event format is auto-detected (string vs map)

## Test plan
- [ ] Android: drag notification seek bar → verify `seekPosition` has correct value
- [ ] Web: drag browser media seek bar → verify `seekPosition` has correct value  
- [x] Windows: no seek support yet (unchanged, no regression)
- [ ] Verify play/pause/skip actions still work (string format, no regression)