### PR TITLE
fix: notification not appearing — addSession + startForegroundService

### DIFF
--- a/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionPlugin.kt
+++ b/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionPlugin.kt
@@ -3,6 +3,7 @@ package dev.wyrin.flutter_media_session
 import android.content.Context
 import android.content.Intent
 import androidx.annotation.NonNull
+import androidx.core.content.ContextCompat
 import androidx.media3.common.util.UnstableApi
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
@@ -54,7 +55,7 @@ class FlutterMediaSessionPlugin: FlutterPlugin, MethodCallHandler {
         when (call.method) {
             "activate" -> {
                 val intent = Intent(context, FlutterMediaSessionService::class.java)
-                context.startService(intent)
+                ContextCompat.startForegroundService(context, intent)
                 result.success(null)
             }
             "deactivate" -> {

--- a/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionPlugin.kt
+++ b/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionPlugin.kt
@@ -89,6 +89,12 @@ class FlutterMediaSessionPlugin: FlutterPlugin, MethodCallHandler {
                 }
                 result.success(null)
             }
+            "updateAvailableActions" -> {
+                @Suppress("UNCHECKED_CAST")
+                val actions = call.arguments as? List<String>
+                FlutterMediaSessionService.instance?.updateAvailableActions(actions)
+                result.success(null)
+            }
             else -> result.notImplemented()
         }
     }

--- a/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionService.kt
+++ b/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionService.kt
@@ -100,6 +100,14 @@ class FlutterMediaSessionService : MediaSessionService() {
     }
 
     /**
+     * Updates which media actions are available in the system controls.
+     * Pass null to enable all actions.
+     */
+    fun updateAvailableActions(actions: List<String>?) {
+        player.updateAvailableActions(actions)
+    }
+
+    /**
      * Callback handler for MediaSession events.
      */
     inner class CustomMediaSessionCallback : MediaSession.Callback {
@@ -121,6 +129,7 @@ class FlutterMediaSessionService : MediaSessionService() {
         private var speed: Float = 1.0f
         private var bufferedPositionMs: Long = 0
         private var durationMs: Long = C.TIME_UNSET
+        private var availableActions: List<String>? = null // null = all enabled
 
         /**
          * Updates the internal metadata state and triggers a state invalidation.
@@ -143,9 +152,17 @@ class FlutterMediaSessionService : MediaSessionService() {
          * Updates the internal playback state and triggers a state invalidation.
          * Also manages the registration of the ACTION_AUDIO_BECOMING_NOISY receiver.
          */
+        /**
+         * Updates which actions are available. Pass null to enable all.
+         */
+        fun updateAvailableActions(actions: List<String>?) {
+            this.availableActions = actions
+            invalidateState()
+        }
+
         fun updatePlaybackState(status: String, positionMs: Long, speed: Float, bufferedPositionMs: Long) {
             val isPlaying = status == "playing"
-            
+
             this.playbackStatus = status
             this.positionMs = positionMs
             this.speed = speed
@@ -171,12 +188,36 @@ class FlutterMediaSessionService : MediaSessionService() {
             }
             val playWhenReady = playbackStatus == "playing"
             
+            val commandsBuilder = Player.Commands.Builder()
+            val actions = availableActions
+            if (actions == null) {
+                commandsBuilder.addAllCommands()
+            } else {
+                // Always allow basic commands
+                commandsBuilder.add(Player.COMMAND_PLAY_PAUSE)
+                commandsBuilder.add(Player.COMMAND_STOP)
+                commandsBuilder.add(Player.COMMAND_GET_CURRENT_MEDIA_ITEM)
+                commandsBuilder.add(Player.COMMAND_GET_METADATA)
+                commandsBuilder.add(Player.COMMAND_GET_TIMELINE)
+                if (actions.contains("seekTo")) {
+                    commandsBuilder.add(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM)
+                    commandsBuilder.add(Player.COMMAND_SEEK_BACK)
+                    commandsBuilder.add(Player.COMMAND_SEEK_FORWARD)
+                }
+                if (actions.contains("skipToNext")) {
+                    commandsBuilder.add(Player.COMMAND_SEEK_TO_NEXT)
+                    commandsBuilder.add(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
+                }
+                if (actions.contains("skipToPrevious")) {
+                    commandsBuilder.add(Player.COMMAND_SEEK_TO_PREVIOUS)
+                    commandsBuilder.add(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
+                }
+                if (actions.contains("rewind")) commandsBuilder.add(Player.COMMAND_SEEK_BACK)
+                if (actions.contains("fastForward")) commandsBuilder.add(Player.COMMAND_SEEK_FORWARD)
+            }
+
             return State.Builder()
-                .setAvailableCommands(
-                    Player.Commands.Builder()
-                        .addAllCommands()
-                        .build()
-                )
+                .setAvailableCommands(commandsBuilder.build())
                 .setPlayWhenReady(playWhenReady, Player.PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST)
                 .setPlaybackState(playerState)
                 .setCurrentMediaItemIndex(0)

--- a/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionService.kt
+++ b/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionService.kt
@@ -50,19 +50,27 @@ class FlutterMediaSessionService : MediaSessionService() {
     }
 
     override fun onCreate() {
-        super.onCreate()
         instance = this
         player = ForwardingPlayer()
-        
+
         // Use the launch intent of the app for the session activity
         val intent = packageManager.getLaunchIntentForPackage(packageName)
         val pendingIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
 
+        // Build the session BEFORE super.onCreate() — Media3 may query
+        // onGetSession() during initialization.
         mediaSession = MediaSession.Builder(this, player)
             .setSessionActivity(pendingIntent)
             .setCallback(CustomMediaSessionCallback())
             .build()
-            
+
+        super.onCreate()
+
+        // Register the session with the service so Media3's
+        // MediaNotificationManager creates its internal MediaController
+        // and starts the notification pipeline.
+        addSession(mediaSession!!)
+
         // Sync any data that was sent to the plugin before the service was ready
         FlutterMediaSessionPlugin.instance?.syncPendingData()
     }
@@ -124,7 +132,7 @@ class FlutterMediaSessionService : MediaSessionService() {
      */
     inner class ForwardingPlayer : androidx.media3.common.SimpleBasePlayer(mainLooper) {
         private var currentMetadata: MediaMetadata = MediaMetadata.EMPTY
-        private var playbackStatus: String = "idle"
+        private var playbackStatus: String = "buffering"
         private var positionMs: Long = 0
         private var speed: Float = 1.0f
         private var bufferedPositionMs: Long = 0

--- a/lib/flutter_media_session.dart
+++ b/lib/flutter_media_session.dart
@@ -48,4 +48,22 @@ class FlutterMediaSession {
   Future<void> updatePlaybackState(PlaybackState state) {
     return FlutterMediaSessionPlatform.instance.updatePlaybackState(state);
   }
+
+  /// Updates which media actions are available in system controls.
+  ///
+  /// Actions not in [actions] will be disabled in the notification.
+  /// Pass null to enable all actions (the default).
+  ///
+  /// Example — disable skip buttons:
+  /// ```dart
+  /// await _mediaSession.updateAvailableActions({
+  ///   MediaAction.play,
+  ///   MediaAction.pause,
+  ///   MediaAction.seekTo,
+  ///   MediaAction.stop,
+  /// });
+  /// ```
+  Future<void> updateAvailableActions(Set<MediaAction>? actions) {
+    return FlutterMediaSessionPlatform.instance.updateAvailableActions(actions);
+  }
 }

--- a/lib/flutter_media_session_method_channel.dart
+++ b/lib/flutter_media_session_method_channel.dart
@@ -35,6 +35,14 @@ class MethodChannelFlutterMediaSession extends FlutterMediaSessionPlatform {
   }
 
   @override
+  Future<void> updateAvailableActions(Set<MediaAction>? actions) async {
+    await methodChannel.invokeMethod(
+      'updateAvailableActions',
+      actions?.map((a) => a.name).toList(),
+    );
+  }
+
+  @override
   Stream<MediaAction> get onMediaAction {
     return eventChannel.receiveBroadcastStream().map((event) {
       if (event is Map) {

--- a/lib/flutter_media_session_platform_interface.dart
+++ b/lib/flutter_media_session_platform_interface.dart
@@ -48,6 +48,15 @@ abstract class FlutterMediaSessionPlatform extends PlatformInterface {
     throw UnimplementedError('updatePlaybackState() has not been implemented.');
   }
 
+  /// Updates the set of media actions available in system controls.
+  ///
+  /// Actions not in [actions] will be disabled (hidden or greyed out)
+  /// in the notification and lock screen. Pass null to enable all actions.
+  Future<void> updateAvailableActions(Set<MediaAction>? actions) {
+    throw UnimplementedError(
+        'updateAvailableActions() has not been implemented.');
+  }
+
   /// A stream of media actions emitted by the current platform.
   Stream<MediaAction> get onMediaAction {
     throw UnimplementedError('onMediaAction has not been implemented.');

--- a/lib/flutter_media_session_web.dart
+++ b/lib/flutter_media_session_web.dart
@@ -117,6 +117,35 @@ class FlutterMediaSessionWeb extends FlutterMediaSessionPlatform {
     }
   }
 
+  /// Map from browser action names to MediaAction constants.
+  static const _webActionMap = {
+    'play': MediaAction.play,
+    'pause': MediaAction.pause,
+    'previoustrack': MediaAction.skipToPrevious,
+    'nexttrack': MediaAction.skipToNext,
+    'stop': MediaAction.stop,
+    'seekbackward': MediaAction.rewind,
+    'seekforward': MediaAction.fastForward,
+    'seekto': MediaAction.seekTo,
+  };
+
+  @override
+  Future<void> updateAvailableActions(Set<MediaAction>? actions) async {
+    try {
+      final session = web.window.navigator.mediaSession;
+      for (final entry in _webActionMap.entries) {
+        if (actions == null || actions.contains(entry.value)) {
+          _registerAction(session, entry.key, entry.value);
+        } else {
+          // Unregister by setting handler to null
+          try {
+            session.setActionHandler(entry.key, null);
+          } catch (_) {}
+        }
+      }
+    } catch (_) {}
+  }
+
   /// Internal helper to register a media action handler with the browser's media session.
   void _registerAction(
       web.MediaSession session, String actionName, MediaAction actionToEmit) {

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -62,7 +62,7 @@ set(flutter_media_session_bundled_libraries
 
 # Only enable test builds when building the example (which sets this variable)
 # so that plugin clients aren't building the tests.
-if (FALSE AND ${include_${PROJECT_NAME}_tests})
+if(FALSE)
 set(TEST_RUNNER "${PROJECT_NAME}_test")
 enable_testing()
 

--- a/windows/flutter_media_session_plugin.cpp
+++ b/windows/flutter_media_session_plugin.cpp
@@ -262,7 +262,7 @@ void FlutterMediaSessionPlugin::HandleMethodCall(
                       else if (*status == "paused") smtcStatus = MediaPlaybackStatus::Paused;
                       else if (*status == "buffering") smtcStatus = MediaPlaybackStatus::Changing;
                       else if (*status == "idle" || *status == "ended" || *status == "error") smtcStatus = MediaPlaybackStatus::Stopped;
-                      
+
                       try {
                           smtc_.PlaybackStatus(smtcStatus);
                       } catch (winrt::hresult_error const& ex) {
@@ -270,6 +270,39 @@ void FlutterMediaSessionPlugin::HandleMethodCall(
                       }
                   }
               }
+          }
+      }
+      result->Success();
+  } else if (method_name == "updateAvailableActions") {
+      if (smtc_) {
+          const auto* actions = std::get_if<flutter::EncodableList>(method_call.arguments());
+          if (actions) {
+              // Check which actions are in the list
+              bool hasPlay = false, hasPause = false, hasNext = false, hasPrevious = false;
+              for (const auto& action : *actions) {
+                  if (auto str = std::get_if<std::string>(&action)) {
+                      if (*str == "play") hasPlay = true;
+                      else if (*str == "pause") hasPause = true;
+                      else if (*str == "skipToNext") hasNext = true;
+                      else if (*str == "skipToPrevious") hasPrevious = true;
+                  }
+              }
+              try {
+                  smtc_.IsPlayEnabled(hasPlay);
+                  smtc_.IsPauseEnabled(hasPause);
+                  smtc_.IsNextEnabled(hasNext);
+                  smtc_.IsPreviousEnabled(hasPrevious);
+              } catch (winrt::hresult_error const& ex) {
+                  OutputDebugStringW((L"SMTC updateAvailableActions error: " + ex.message() + L"\n").c_str());
+              }
+          } else {
+              // null = enable all
+              try {
+                  smtc_.IsPlayEnabled(true);
+                  smtc_.IsPauseEnabled(true);
+                  smtc_.IsNextEnabled(true);
+                  smtc_.IsPreviousEnabled(true);
+              } catch (...) {}
           }
       }
       result->Success();


### PR DESCRIPTION
## Summary
Builds on #2 (available actions). Fixes the notification not appearing on Android.

### Root Cause
`MediaSessionService.addSession()` was never called. Without it, Media3's `MediaNotificationManager` never creates its internal `MediaController`, so the notification pipeline never starts. `onGetSession()` is only called when a controller connects — it's not automatically invoked by `super.onCreate()`.

### Changes
1. **Call `addSession(mediaSession!!)`** after `super.onCreate()` — registers the session with Media3's notification system
2. **Use `ContextCompat.startForegroundService()`** instead of `startService()` for proper Android 8+ handling
3. **Default player state to BUFFERING** instead of IDLE — Media3 only shows notifications for non-idle states
4. **Build MediaSession before `super.onCreate()`** so it's ready when Media3 queries `onGetSession()`

### Verified
- Notification appears on Pixel 10 Pro (Android 16 / SDK 36)
- Play/pause/seek controls work from notification
- Notification updates with correct title and position