### PR TITLE
feat: complete seekTo cross-platform support and optimize example app buffering state

### DIFF
--- a/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionPlugin.kt
+++ b/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionPlugin.kt
@@ -106,7 +106,11 @@ class FlutterMediaSessionPlugin: FlutterPlugin, MethodCallHandler {
      */
     fun sendAction(action: String, args: Any? = null) {
         android.os.Handler(android.os.Looper.getMainLooper()).post {
-            eventSink?.success(action)
+            if (args != null) {
+                eventSink?.success(mapOf("action" to action, "args" to args))
+            } else {
+                eventSink?.success(action)
+            }
         }
     }
 

--- a/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionService.kt
+++ b/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionService.kt
@@ -117,7 +117,8 @@ class FlutterMediaSessionService : MediaSessionService() {
     inner class ForwardingPlayer : androidx.media3.common.SimpleBasePlayer(mainLooper) {
         private var currentMetadata: MediaMetadata = MediaMetadata.EMPTY
         private var playbackStatus: String = "idle"
-        private var positionMs: Long = 0
+        private var lastPositionMs: Long = 0
+        private var lastPositionUpdateTimeMs: Long = android.os.SystemClock.elapsedRealtime()
         private var speed: Float = 1.0f
         private var bufferedPositionMs: Long = 0
         private var durationMs: Long = C.TIME_UNSET
@@ -147,7 +148,8 @@ class FlutterMediaSessionService : MediaSessionService() {
             val isPlaying = status == "playing"
             
             this.playbackStatus = status
-            this.positionMs = positionMs
+            this.lastPositionMs = positionMs
+            this.lastPositionUpdateTimeMs = android.os.SystemClock.elapsedRealtime()
             this.speed = speed
             this.bufferedPositionMs = bufferedPositionMs
             invalidateState()
@@ -181,12 +183,21 @@ class FlutterMediaSessionService : MediaSessionService() {
                 .setPlaybackState(playerState)
                 .setCurrentMediaItemIndex(0)
                 .setPlaylist(listOf(
-                    MediaItemData.Builder(0)
+                    MediaItemData.Builder("channel_0")
+                        .setMediaItem(MediaItem.Builder().setMediaId("channel_0").setMediaMetadata(currentMetadata).build())
                         .setMediaMetadata(currentMetadata)
                         .setDurationUs(if (durationMs != C.TIME_UNSET) durationMs * 1000 else C.TIME_UNSET)
                         .build()
                 ))
-                .setContentPositionMs { positionMs }
+                .setContentPositionMs {
+                    val position = if (playbackStatus == "playing") {
+                        val elapsed = android.os.SystemClock.elapsedRealtime() - lastPositionUpdateTimeMs
+                        lastPositionMs + (elapsed * speed).toLong()
+                    } else {
+                        lastPositionMs
+                    }
+                    if (durationMs != C.TIME_UNSET && position > durationMs) durationMs else position
+                }
                 .setContentBufferedPositionMs { bufferedPositionMs }
                 .setPlaybackParameters(PlaybackParameters(speed))
                 .build()
@@ -206,6 +217,10 @@ class FlutterMediaSessionService : MediaSessionService() {
                     FlutterMediaSessionPlugin.instance?.sendAction("skipToPrevious")
                 }
                 else -> {
+                    // Update internal state immediately for better responsiveness
+                    this.lastPositionMs = positionMs
+                    this.lastPositionUpdateTimeMs = android.os.SystemClock.elapsedRealtime()
+                    invalidateState()
                     FlutterMediaSessionPlugin.instance?.sendAction("seekTo", positionMs)
                 }
             }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -137,7 +137,8 @@ class _PlayerHomeState extends State<PlayerHome> {
           _position = p;
           if (!_isSwitchingTrack) _isBuffering = false;
         });
-        _updatePlayback();
+        // System Media Sessions (Android/Windows) extrapolate position automatically.
+        // Spamming updates overrides extrapolation and breaks external controllers (e.g., KDE Connect).
       }
     }));
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_media_session/flutter_media_session.dart';
+import 'dart:async';
 import 'package:audioplayers/audioplayers.dart';
 
 void main() {
@@ -57,6 +58,9 @@ class _PlayerHomeState extends State<PlayerHome> {
   Duration _position = Duration.zero;
   Duration _currentDuration = Duration.zero;
 
+  String? _loadedUrl;
+  Timer? _seekDebounce;
+
   final List<Track> _playlist = List.generate(17, (index) {
     final id = index + 1;
     return Track(
@@ -90,6 +94,20 @@ class _PlayerHomeState extends State<PlayerHome> {
           break;
         case MediaAction.skipToPrevious:
           _prev();
+          break;
+        case MediaAction.seekTo:
+          if (action.seekPosition != null) {
+            final newPosition = action.seekPosition!;
+            if (mounted) {
+              setState(() => _position = newPosition);
+            }
+            _updatePlayback();
+            
+            _seekDebounce?.cancel();
+            _seekDebounce = Timer(const Duration(milliseconds: 300), () {
+              _audioPlayer.seek(newPosition).catchError((_) {});
+            });
+          }
           break;
         default:
           break;
@@ -165,12 +183,14 @@ class _PlayerHomeState extends State<PlayerHome> {
       if (_status != PlaybackStatus.playing) _isBuffering = true;
     });
     try {
-      if (_audioPlayer.source == null || _position == Duration.zero) {
+      if (_loadedUrl != current.url || _audioPlayer.source == null) {
+        _loadedUrl = current.url;
         await _audioPlayer.play(UrlSource(current.url));
       } else {
         await _audioPlayer.resume();
       }
     } catch (e) {
+      debugPrint("Play error: $e");
       _handleError();
     }
   }
@@ -180,7 +200,7 @@ class _PlayerHomeState extends State<PlayerHome> {
   Future<void> _prev() async => _changeTrack(-1);
 
   void _changeTrack(int step) async {
-    await _audioPlayer.stop();
+    await _audioPlayer.stop().catchError((_) {});
     setState(() {
       _isSwitchingTrack = true;
       _currentIndex =
@@ -190,14 +210,18 @@ class _PlayerHomeState extends State<PlayerHome> {
       _isBuffering = true;
       _hasError = false;
       _status = PlaybackStatus.idle;
+      _loadedUrl = current.url;
     });
     _updateAll();
-    try {
-      await Future.delayed(const Duration(milliseconds: 50));
-      await _audioPlayer.play(UrlSource(current.url));
-    } catch (e) {
-      _handleError();
-    }
+    
+    Future.delayed(const Duration(milliseconds: 50), () async {
+      try {
+        await _audioPlayer.play(UrlSource(current.url));
+      } catch (e) {
+        debugPrint("Change track error: $e");
+        _handleError();
+      }
+    });
   }
 
   void _handleError() {
@@ -239,12 +263,13 @@ class _PlayerHomeState extends State<PlayerHome> {
 
   @override
   void dispose() {
+    _seekDebounce?.cancel();
     _audioPlayer.dispose();
     super.dispose();
   }
 
   String _format(Duration d) {
-    if (_isBuffering || d == Duration.zero) return "--:--";
+    if (_isBuffering || _isSwitchingTrack) return "--:--";
     String two(int n) => n.toString().padLeft(2, '0');
     return "${two(d.inMinutes)}:${two(d.inSeconds % 60)}";
   }
@@ -322,7 +347,10 @@ class _PlayerHomeState extends State<PlayerHome> {
                 // Playback Progress
                 SizedBox(
                   height: 20,
-                  child: (_isBuffering || _currentDuration <= Duration.zero)
+                  child: (_isBuffering ||
+                          _isSwitchingTrack ||
+                          (_status == PlaybackStatus.playing &&
+                              _currentDuration <= Duration.zero))
                       ? Center(
                           child: LinearProgressIndicator(
                             minHeight: 12.0,
@@ -344,7 +372,9 @@ class _PlayerHomeState extends State<PlayerHome> {
                                   _currentDuration.inMilliseconds.toDouble(),
                                 ),
                             min: 0.0,
-                            max: _currentDuration.inMilliseconds.toDouble(),
+                            max: _currentDuration.inMilliseconds.toDouble() > 0
+                                ? _currentDuration.inMilliseconds.toDouble()
+                                : 1.0,
                             onChanged: _hasError
                                 ? null
                                 : (v) {
@@ -352,7 +382,14 @@ class _PlayerHomeState extends State<PlayerHome> {
                                       milliseconds: v.toInt(),
                                     );
                                     setState(() => _position = newPosition);
-                                    _audioPlayer.seek(newPosition);
+                                  },
+                            onChangeEnd: _hasError
+                                ? null
+                                : (v) {
+                                    final newPosition = Duration(
+                                      milliseconds: v.toInt(),
+                                    );
+                                    _audioPlayer.seek(newPosition).catchError((_) {});
                                     _updatePlayback();
                                   },
                           ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -60,6 +60,7 @@ class _PlayerHomeState extends State<PlayerHome> {
 
   String? _loadedUrl;
   Timer? _seekDebounce;
+  final List<StreamSubscription> _subscriptions = [];
 
   final List<Track> _playlist = List.generate(17, (index) {
     final id = index + 1;
@@ -81,7 +82,7 @@ class _PlayerHomeState extends State<PlayerHome> {
   }
 
   void _listenMediaSessionActions() {
-    _plugin.onMediaAction.listen((action) {
+    _subscriptions.add(_plugin.onMediaAction.listen((action) {
       switch (action) {
         case MediaAction.play:
           _play();
@@ -102,21 +103,25 @@ class _PlayerHomeState extends State<PlayerHome> {
               setState(() => _position = newPosition);
             }
             _updatePlayback();
-            
+
+            // Debouncing external seek commands to avoid flooding the audio player.
+            // 200ms provides a good balance between responsiveness and stability.
             _seekDebounce?.cancel();
-            _seekDebounce = Timer(const Duration(milliseconds: 300), () {
-              _audioPlayer.seek(newPosition).catchError((_) {});
+            _seekDebounce = Timer(const Duration(milliseconds: 200), () {
+              if (mounted) {
+                _audioPlayer.seek(newPosition).catchError((_) {});
+              }
             });
           }
           break;
         default:
           break;
       }
-    });
+    }));
   }
 
   void _listenAudioPlayerEvents() {
-    _audioPlayer.onDurationChanged.listen((Duration d) {
+    _subscriptions.add(_audioPlayer.onDurationChanged.listen((Duration d) {
       if (mounted) {
         setState(() {
           _currentDuration = d;
@@ -124,9 +129,9 @@ class _PlayerHomeState extends State<PlayerHome> {
         });
         _updateAll();
       }
-    });
+    }));
 
-    _audioPlayer.onPositionChanged.listen((p) {
+    _subscriptions.add(_audioPlayer.onPositionChanged.listen((p) {
       if (mounted) {
         setState(() {
           _position = p;
@@ -134,11 +139,11 @@ class _PlayerHomeState extends State<PlayerHome> {
         });
         _updatePlayback();
       }
-    });
+    }));
 
-    _audioPlayer.onPlayerComplete.listen((event) => _next());
+    _subscriptions.add(_audioPlayer.onPlayerComplete.listen((event) => _next()));
 
-    _audioPlayer.onPlayerStateChanged.listen((state) {
+    _subscriptions.add(_audioPlayer.onPlayerStateChanged.listen((state) {
       if (mounted) {
         setState(() {
           if (state == PlayerState.playing) {
@@ -156,7 +161,7 @@ class _PlayerHomeState extends State<PlayerHome> {
         });
         _updatePlayback();
       }
-    });
+    }));
   }
 
   Future<void> _activate() async {
@@ -166,6 +171,7 @@ class _PlayerHomeState extends State<PlayerHome> {
   }
 
   Future<void> _deactivate() async {
+    _seekDebounce?.cancel();
     await _plugin.deactivate();
     await _audioPlayer.stop();
     setState(() {
@@ -200,6 +206,7 @@ class _PlayerHomeState extends State<PlayerHome> {
   Future<void> _prev() async => _changeTrack(-1);
 
   void _changeTrack(int step) async {
+    _seekDebounce?.cancel();
     await _audioPlayer.stop().catchError((_) {});
     setState(() {
       _isSwitchingTrack = true;
@@ -263,6 +270,10 @@ class _PlayerHomeState extends State<PlayerHome> {
 
   @override
   void dispose() {
+    for (final subscription in _subscriptions) {
+      subscription.cancel();
+    }
+    _subscriptions.clear();
     _seekDebounce?.cancel();
     _audioPlayer.dispose();
     super.dispose();
@@ -375,7 +386,7 @@ class _PlayerHomeState extends State<PlayerHome> {
                             max: _currentDuration.inMilliseconds.toDouble() > 0
                                 ? _currentDuration.inMilliseconds.toDouble()
                                 : 1.0,
-                            onChanged: _hasError
+                            onChanged: (_hasError || _currentDuration <= Duration.zero)
                                 ? null
                                 : (v) {
                                     final newPosition = Duration(
@@ -383,7 +394,7 @@ class _PlayerHomeState extends State<PlayerHome> {
                                     );
                                     setState(() => _position = newPosition);
                                   },
-                            onChangeEnd: _hasError
+                            onChangeEnd: (_hasError || _currentDuration <= Duration.zero)
                                 ? null
                                 : (v) {
                                     final newPosition = Duration(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -60,6 +60,7 @@ class _PlayerHomeState extends State<PlayerHome> {
 
   String? _loadedUrl;
   Timer? _seekDebounce;
+  DateTime _lastSeekTime = DateTime.fromMillisecondsSinceEpoch(0);
   final List<StreamSubscription> _subscriptions = [];
 
   final List<Track> _playlist = List.generate(17, (index) {
@@ -100,7 +101,10 @@ class _PlayerHomeState extends State<PlayerHome> {
           if (action.seekPosition != null) {
             final newPosition = action.seekPosition!;
             if (mounted) {
-              setState(() => _position = newPosition);
+              setState(() {
+                _position = newPosition;
+                _lastSeekTime = DateTime.now();
+              });
             }
             _updatePlayback();
 
@@ -133,16 +137,21 @@ class _PlayerHomeState extends State<PlayerHome> {
 
     _subscriptions.add(_audioPlayer.onPositionChanged.listen((p) {
       if (mounted) {
+        // Ignore stale position updates for 500ms after a seek to prevent UI flickering
+        if (DateTime.now().difference(_lastSeekTime).inMilliseconds < 500) return;
+        
+        final wasBuffering = _isBuffering;
         setState(() {
           _position = p;
           if (!_isSwitchingTrack) _isBuffering = false;
         });
+        if (wasBuffering && !_isBuffering) _updatePlayback();
         // System Media Sessions (Android/Windows) extrapolate position automatically.
-        // Spamming updates overrides extrapolation and breaks external controllers (e.g., KDE Connect).
       }
     }));
 
-    _subscriptions.add(_audioPlayer.onPlayerComplete.listen((event) => _next()));
+    _subscriptions
+        .add(_audioPlayer.onPlayerComplete.listen((event) => _next()));
 
     _subscriptions.add(_audioPlayer.onPlayerStateChanged.listen((state) {
       if (mounted) {
@@ -221,7 +230,7 @@ class _PlayerHomeState extends State<PlayerHome> {
       _loadedUrl = current.url;
     });
     _updateAll();
-    
+
     Future.delayed(const Duration(milliseconds: 50), () async {
       try {
         await _audioPlayer.play(UrlSource(current.url));
@@ -261,9 +270,16 @@ class _PlayerHomeState extends State<PlayerHome> {
 
   Future<void> _updatePlayback() async {
     if (!_active) return;
+    PlaybackStatus status = _status;
+    if (_isSwitchingTrack) {
+      status = PlaybackStatus.idle;
+    } else if (_isBuffering) {
+      status = PlaybackStatus.buffering;
+    }
+
     await _plugin.updatePlaybackState(
       PlaybackState(
-        status: _isSwitchingTrack ? PlaybackStatus.idle : _status,
+        status: status,
         position: _position,
       ),
     );
@@ -387,23 +403,31 @@ class _PlayerHomeState extends State<PlayerHome> {
                             max: _currentDuration.inMilliseconds.toDouble() > 0
                                 ? _currentDuration.inMilliseconds.toDouble()
                                 : 1.0,
-                            onChanged: (_hasError || _currentDuration <= Duration.zero)
-                                ? null
-                                : (v) {
-                                    final newPosition = Duration(
-                                      milliseconds: v.toInt(),
-                                    );
-                                    setState(() => _position = newPosition);
-                                  },
-                            onChangeEnd: (_hasError || _currentDuration <= Duration.zero)
-                                ? null
-                                : (v) {
-                                    final newPosition = Duration(
-                                      milliseconds: v.toInt(),
-                                    );
-                                    _audioPlayer.seek(newPosition).catchError((_) {});
-                                    _updatePlayback();
-                                  },
+                            onChanged:
+                                (_hasError || _currentDuration <= Duration.zero)
+                                    ? null
+                                    : (v) {
+                                        final newPosition = Duration(
+                                          milliseconds: v.toInt(),
+                                        );
+                                        setState(() => _position = newPosition);
+                                      },
+                            onChangeEnd:
+                                (_hasError || _currentDuration <= Duration.zero)
+                                    ? null
+                                    : (v) {
+                                        final newPosition = Duration(
+                                          milliseconds: v.toInt(),
+                                        );
+                                        setState(() {
+                                          _position = newPosition;
+                                          _lastSeekTime = DateTime.now();
+                                        });
+                                        _audioPlayer
+                                            .seek(newPosition)
+                                            .catchError((_) {});
+                                        _updatePlayback();
+                                      },
                           ),
                         ),
                 ),

--- a/lib/flutter_media_session_method_channel.dart
+++ b/lib/flutter_media_session_method_channel.dart
@@ -37,6 +37,17 @@ class MethodChannelFlutterMediaSession extends FlutterMediaSessionPlatform {
   @override
   Stream<MediaAction> get onMediaAction {
     return eventChannel.receiveBroadcastStream().map((event) {
+      if (event is Map) {
+        final action = event['action'] as String;
+        final args = event['args'];
+        if (action == 'seekTo' && args is num) {
+          return MediaAction(
+            action,
+            seekPosition: Duration(milliseconds: args.toInt()),
+          );
+        }
+        return MediaAction(action);
+      }
       return MediaAction(event as String);
     });
   }

--- a/lib/flutter_media_session_web.dart
+++ b/lib/flutter_media_session_web.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:web/web.dart' as web;
@@ -124,7 +125,16 @@ class FlutterMediaSessionWeb extends FlutterMediaSessionPlatform {
       session.setActionHandler(
           actionName,
           ((JSAny? details) {
-            // Todo: For 'seekto', extract the seek position from details if needed.
+            if (actionName == 'seekto' && details != null) {
+              final seekTime = (details as JSObject).getProperty<JSNumber?>('seekTime'.toJS)?.toDartDouble;
+              if (seekTime != null) {
+                _actionController.add(MediaAction(
+                  'seekTo',
+                  seekPosition: Duration(milliseconds: (seekTime * 1000).round()),
+                ));
+                return;
+              }
+            }
             _actionController.add(actionToEmit);
           }).toJS);
     } catch (e) {

--- a/lib/src/models/media_action.dart
+++ b/lib/src/models/media_action.dart
@@ -3,8 +3,12 @@ class MediaAction {
   /// The unique name of the action.
   final String name;
 
-  /// Creates a new [MediaAction] instance with the given [name].
-  const MediaAction(this.name);
+  /// Optional seek position in milliseconds (only set for [seekTo] actions).
+  final Duration? seekPosition;
+
+  /// Creates a new [MediaAction] instance with the given [name] and optional
+  /// [seekPosition].
+  const MediaAction(this.name, {this.seekPosition});
 
   /// Action to resume playback.
   static const play = MediaAction('play');
@@ -22,6 +26,10 @@ class MediaAction {
   static const stop = MediaAction('stop');
 
   /// Action to seek to a specific position.
+  ///
+  /// When received from system controls, [seekPosition] contains the target
+  /// position. Use [MediaAction.seekTo] as a constant only for equality checks;
+  /// actual seek events will have a non-null [seekPosition].
   static const seekTo = MediaAction('seekTo');
 
   /// Action to rewind playback by a standard interval.
@@ -41,5 +49,6 @@ class MediaAction {
   int get hashCode => name.hashCode;
 
   @override
-  String toString() => name;
+  String toString() =>
+      seekPosition != null ? '$name(${seekPosition!.inMilliseconds}ms)' : name;
 }

--- a/windows/flutter_media_session_plugin.cpp
+++ b/windows/flutter_media_session_plugin.cpp
@@ -38,6 +38,7 @@ enum MediaActionId {
   Pause,
   SkipToNext,
   SkipToPrevious,
+  SeekTo,
 };
 
 // static
@@ -145,6 +146,14 @@ void FlutterMediaSessionPlugin::InitSmtc() {
                 PostMessage(root_hwnd, WM_MEDIA_ACTION, (WPARAM)action_id, 0);
             }
         });
+
+        playback_position_change_requested_token_ = smtc_.PlaybackPositionChangeRequested([this, root_hwnd](SystemMediaTransportControls const&, PlaybackPositionChangeRequestedEventArgs const& args) {
+            if (root_hwnd) {
+                // Pass position in milliseconds through lparam.
+                int64_t position_ms = args.RequestedPlaybackPosition().count() / 10000; // WinRT duration is in 100ns units
+                PostMessage(root_hwnd, WM_MEDIA_ACTION, (WPARAM)MediaActionId::SeekTo, (LPARAM)position_ms);
+            }
+        });
         
     } catch (winrt::hresult_error const& ex) {
         OutputDebugStringW((L"InitSmtc HRESULT error: " + ex.message() + L"\n").c_str());
@@ -162,6 +171,7 @@ void FlutterMediaSessionPlugin::DisposeSmtc() {
     if (smtc_) {
         smtc_.IsEnabled(false);
         smtc_.ButtonPressed(button_pressed_token_);
+        smtc_.PlaybackPositionChangeRequested(playback_position_change_requested_token_);
         smtc_ = nullptr;
     }
 }
@@ -178,11 +188,19 @@ std::optional<LRESULT> FlutterMediaSessionPlugin::HandleWindowProc(HWND hwnd, UI
             case MediaActionId::Pause: actionStr = "pause"; break;
             case MediaActionId::SkipToNext: actionStr = "skipToNext"; break;
             case MediaActionId::SkipToPrevious: actionStr = "skipToPrevious"; break;
+            case MediaActionId::SeekTo: actionStr = "seekTo"; break;
             default: break;
         }
 
         if (!actionStr.empty() && event_sink_) {
-            event_sink_->Success(flutter::EncodableValue(actionStr));
+            if (id == MediaActionId::SeekTo) {
+                flutter::EncodableMap args;
+                args[flutter::EncodableValue("action")] = flutter::EncodableValue(actionStr);
+                args[flutter::EncodableValue("args")] = flutter::EncodableValue((int64_t)lparam);
+                event_sink_->Success(flutter::EncodableValue(args));
+            } else {
+                event_sink_->Success(flutter::EncodableValue(actionStr));
+            }
         }
         return 0; // Handled
     }

--- a/windows/flutter_media_session_plugin.cpp
+++ b/windows/flutter_media_session_plugin.cpp
@@ -174,6 +174,7 @@ void FlutterMediaSessionPlugin::DisposeSmtc() {
         smtc_.PlaybackPositionChangeRequested(playback_position_change_requested_token_);
         smtc_ = nullptr;
     }
+    duration_ms_ = 0;
 }
 
 /**
@@ -260,9 +261,28 @@ void FlutterMediaSessionPlugin::HandleMethodCall(
                       }
                   }
               }
+              
+              auto itDuration = args->find(flutter::EncodableValue("durationMs"));
+              if (itDuration != args->end() && !itDuration->second.IsNull()) {
+                  if (auto duration64 = std::get_if<int64_t>(&itDuration->second)) {
+                      duration_ms_ = *duration64;
+                  } else if (auto duration32 = std::get_if<int32_t>(&itDuration->second)) {
+                      duration_ms_ = *duration32;
+                  }
+              }
           }
           try {
               updater.Update();
+              
+              if (duration_ms_ > 0) {
+                  winrt::Windows::Media::SystemMediaTransportControlsTimelineProperties timelineProperties;
+                  timelineProperties.StartTime(winrt::Windows::Foundation::TimeSpan::zero());
+                  timelineProperties.MinSeekTime(winrt::Windows::Foundation::TimeSpan::zero());
+                  timelineProperties.EndTime(winrt::Windows::Foundation::TimeSpan(duration_ms_ * 10000));
+                  timelineProperties.MaxSeekTime(winrt::Windows::Foundation::TimeSpan(duration_ms_ * 10000));
+                  timelineProperties.Position(winrt::Windows::Foundation::TimeSpan::zero());
+                  smtc_.UpdateTimelineProperties(timelineProperties);
+              }
           } catch (winrt::hresult_error const& ex) {
               OutputDebugStringW((L"SMTC Metadata Update error: " + ex.message() + L"\n").c_str());
           }
@@ -285,6 +305,30 @@ void FlutterMediaSessionPlugin::HandleMethodCall(
                           smtc_.PlaybackStatus(smtcStatus);
                       } catch (winrt::hresult_error const& ex) {
                           OutputDebugStringW((L"SMTC PlaybackStatus update error: " + ex.message() + L"\n").c_str());
+                      }
+                  }
+              }
+
+              auto itPosition = args->find(flutter::EncodableValue("positionMs"));
+              if (itPosition != args->end() && !itPosition->second.IsNull()) {
+                  int64_t pos_ms = -1;
+                  if (auto position64 = std::get_if<int64_t>(&itPosition->second)) {
+                      pos_ms = *position64;
+                  } else if (auto position32 = std::get_if<int32_t>(&itPosition->second)) {
+                      pos_ms = *position32;
+                  }
+                  
+                  if (pos_ms >= 0 && duration_ms_ > 0) {
+                      try {
+                          winrt::Windows::Media::SystemMediaTransportControlsTimelineProperties timelineProperties;
+                          timelineProperties.StartTime(winrt::Windows::Foundation::TimeSpan::zero());
+                          timelineProperties.MinSeekTime(winrt::Windows::Foundation::TimeSpan::zero());
+                          timelineProperties.EndTime(winrt::Windows::Foundation::TimeSpan(duration_ms_ * 10000)); // 100ns units
+                          timelineProperties.MaxSeekTime(winrt::Windows::Foundation::TimeSpan(duration_ms_ * 10000));
+                          timelineProperties.Position(winrt::Windows::Foundation::TimeSpan(pos_ms * 10000));
+                          smtc_.UpdateTimelineProperties(timelineProperties);
+                      } catch (winrt::hresult_error const& ex) {
+                          OutputDebugStringW((L"SMTC TimelineProperties update error: " + ex.message() + L"\n").c_str());
                       }
                   }
               }

--- a/windows/flutter_media_session_plugin.h
+++ b/windows/flutter_media_session_plugin.h
@@ -87,6 +87,8 @@ private:
    * Disables and releases the System Media Transport Controls.
    */
   void DisposeSmtc();
+
+  int64_t duration_ms_ = 0;
 };
 
 } // namespace flutter_media_session

--- a/windows/flutter_media_session_plugin.h
+++ b/windows/flutter_media_session_plugin.h
@@ -64,6 +64,7 @@ private:
   // WinRT System Media Transport Controls (SMTC) objects and tokens.
   winrt::Windows::Media::SystemMediaTransportControls smtc_{nullptr};
   winrt::event_token button_pressed_token_;
+  winrt::event_token playback_position_change_requested_token_;
   winrt::event_token status_changed_token_;
 
   /**


### PR DESCRIPTION
## Summary
This PR completes cross-platform support for the `seekTo` feature (especially on Windows) and improves the initial buffering state display logic in the example application. It also builds upon the work introduced in PR #1.

## Key Changes

### Windows `seekTo` Support
- Implemented handling for the `SMTC PlaybackPositionChangeRequested` event in `windows/flutter_media_session_plugin.cpp`, enabling proper synchronization of the progress bar in the Windows system media controls.
- Updated the Windows plugin header and CPP files to support passing the seek position to the Dart layer.

### Example App Improvements
- Fixed an issue on Web where the UI would remain stuck in a "buffering" state on startup.
- When the player is idle and waiting to play, it now correctly displays a `00:00` progress bar instead of a continuous loading spinner.
- The `LinearProgressIndicator` is now shown only when data is actually loading during playback.

### Cross-Platform Consistency
- Reviewed and aligned the `seekTo` parameter handling logic across Android and Web to ensure consistent behavior.

## Testing
- [x] **Web**: Initial load displays correctly; playback and seeking work as expected.
- [x] **Windows**: The system media control progress bar now supports accurate seeking.
- [x] **Android**: Behavior verified to be consistent.