### PR TITLE
feat: implement updateAvailableActions to enable/disable media controls

### DIFF
--- a/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionPlugin.kt
+++ b/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionPlugin.kt
@@ -24,6 +24,7 @@ class FlutterMediaSessionPlugin: FlutterPlugin, MethodCallHandler {
 
     private var pendingMetadata: Map<String, Any?>? = null
     private var pendingPlaybackState: Map<String, Any?>? = null
+    private var pendingAvailableActions: List<String>? = null
 
     companion object {
         /**
@@ -89,6 +90,16 @@ class FlutterMediaSessionPlugin: FlutterPlugin, MethodCallHandler {
                 }
                 result.success(null)
             }
+            "updateAvailableActions" -> {
+                @Suppress("UNCHECKED_CAST")
+                val actions = call.arguments as? List<String>
+                if (FlutterMediaSessionService.instance != null) {
+                    FlutterMediaSessionService.instance?.updateAvailableActions(actions)
+                } else {
+                    pendingAvailableActions = actions
+                }
+                result.success(null)
+            }
             else -> result.notImplemented()
         }
     }
@@ -137,6 +148,11 @@ class FlutterMediaSessionPlugin: FlutterPlugin, MethodCallHandler {
             val bufferedPositionMs = (it["bufferedPositionMs"] as? Number)?.toLong() ?: 0L
             service.updatePlaybackState(status, positionMs, speed, bufferedPositionMs)
             pendingPlaybackState = null
+        }
+
+        pendingAvailableActions?.let {
+            service.updateAvailableActions(it)
+            pendingAvailableActions = null
         }
     }
 }

--- a/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionService.kt
+++ b/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionService.kt
@@ -100,6 +100,13 @@ class FlutterMediaSessionService : MediaSessionService() {
     }
 
     /**
+     * Updates the set of media actions available in the system controls.
+     */
+    fun updateAvailableActions(actions: List<String>?) {
+        player.updateAvailableActions(actions)
+    }
+
+    /**
      * Callback handler for MediaSession events.
      */
     inner class CustomMediaSessionCallback : MediaSession.Callback {
@@ -122,6 +129,7 @@ class FlutterMediaSessionService : MediaSessionService() {
         private var speed: Float = 1.0f
         private var bufferedPositionMs: Long = 0
         private var durationMs: Long = C.TIME_UNSET
+        private var availableActions: List<String>? = null
 
         /**
          * Updates the internal metadata state and triggers a state invalidation.
@@ -137,6 +145,14 @@ class FlutterMediaSessionService : MediaSessionService() {
                 .setArtworkUri(artworkUri?.let { android.net.Uri.parse(it) })
                 .build()
             this.durationMs = if (durationMs > 0) durationMs else C.TIME_UNSET
+            invalidateState()
+        }
+
+        /**
+         * Updates which actions are available in the system controls.
+         */
+        fun updateAvailableActions(actions: List<String>?) {
+            this.availableActions = actions
             invalidateState()
         }
 
@@ -172,13 +188,44 @@ class FlutterMediaSessionService : MediaSessionService() {
                 else -> Player.STATE_IDLE
             }
             val playWhenReady = playbackStatus == "playing"
+
+            val commandsBuilder = Player.Commands.Builder()
+            val actions = availableActions
+            if (actions == null) {
+                commandsBuilder.addAllCommands()
+            } else {
+                // Basic commands that don't belong to actions
+                commandsBuilder.add(Player.COMMAND_GET_CURRENT_MEDIA_ITEM)
+                commandsBuilder.add(Player.COMMAND_GET_METADATA)
+                commandsBuilder.add(Player.COMMAND_GET_TIMELINE)
+                
+                if (actions.contains("play") || actions.contains("pause")) {
+                    commandsBuilder.add(Player.COMMAND_PLAY_PAUSE)
+                }
+                if (actions.contains("stop")) {
+                    commandsBuilder.add(Player.COMMAND_STOP)
+                }
+                if (actions.contains("seekTo")) {
+                    commandsBuilder.add(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM)
+                }
+                if (actions.contains("skipToNext")) {
+                    commandsBuilder.add(Player.COMMAND_SEEK_TO_NEXT)
+                    commandsBuilder.add(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
+                }
+                if (actions.contains("skipToPrevious")) {
+                    commandsBuilder.add(Player.COMMAND_SEEK_TO_PREVIOUS)
+                    commandsBuilder.add(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
+                }
+                if (actions.contains("rewind")) {
+                    commandsBuilder.add(Player.COMMAND_SEEK_BACK)
+                }
+                if (actions.contains("fastForward")) {
+                    commandsBuilder.add(Player.COMMAND_SEEK_FORWARD)
+                }
+            }
             
             return State.Builder()
-                .setAvailableCommands(
-                    Player.Commands.Builder()
-                        .addAllCommands()
-                        .build()
-                )
+                .setAvailableCommands(commandsBuilder.build())
                 .setPlayWhenReady(playWhenReady, Player.PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST)
                 .setPlaybackState(playerState)
                 .setCurrentMediaItemIndex(0)

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -57,6 +57,7 @@ class _PlayerHomeState extends State<PlayerHome> {
   int _currentIndex = 0;
   Duration _position = Duration.zero;
   Duration _currentDuration = Duration.zero;
+  Set<MediaAction>? _availableActions;
 
   String? _loadedUrl;
   Timer? _seekDebounce;
@@ -177,7 +178,13 @@ class _PlayerHomeState extends State<PlayerHome> {
   Future<void> _activate() async {
     await _plugin.activate();
     setState(() => _active = true);
+    await _updateAvailableActions();
     await _updateAll();
+  }
+
+  Future<void> _updateAvailableActions() async {
+    if (!_active) return;
+    await _plugin.updateAvailableActions(_availableActions);
   }
 
   Future<void> _deactivate() async {
@@ -194,6 +201,7 @@ class _PlayerHomeState extends State<PlayerHome> {
   }
 
   Future<void> _play() async {
+    if (_availableActions != null && !_availableActions!.contains(MediaAction.play)) return;
     setState(() {
       _hasError = false;
       if (_status != PlaybackStatus.playing) _isBuffering = true;
@@ -206,14 +214,31 @@ class _PlayerHomeState extends State<PlayerHome> {
         await _audioPlayer.resume();
       }
     } catch (e) {
+      if (e.toString().contains('AbortError') || e.toString().contains('interrupted')) {
+        // A known race condition in browsers when pause is called right after play
+        return;
+      }
       debugPrint("Play error: $e");
       _handleError();
     }
   }
 
-  Future<void> _pause() async => await _audioPlayer.pause();
-  Future<void> _next() async => _changeTrack(1);
-  Future<void> _prev() async => _changeTrack(-1);
+  Future<void> _pause() async {
+    if (_availableActions != null && !_availableActions!.contains(MediaAction.pause)) return;
+    try {
+      await _audioPlayer.pause();
+    } catch (_) {}
+  }
+  
+  Future<void> _next() async {
+    if (_availableActions != null && !_availableActions!.contains(MediaAction.skipToNext)) return;
+    _changeTrack(1);
+  }
+  
+  Future<void> _prev() async {
+    if (_availableActions != null && !_availableActions!.contains(MediaAction.skipToPrevious)) return;
+    _changeTrack(-1);
+  }
 
   void _changeTrack(int step) async {
     _seekDebounce?.cancel();
@@ -235,6 +260,7 @@ class _PlayerHomeState extends State<PlayerHome> {
       try {
         await _audioPlayer.play(UrlSource(current.url));
       } catch (e) {
+        if (e.toString().contains('AbortError') || e.toString().contains('interrupted')) return;
         debugPrint("Change track error: $e");
         _handleError();
       }
@@ -404,7 +430,7 @@ class _PlayerHomeState extends State<PlayerHome> {
                                 ? _currentDuration.inMilliseconds.toDouble()
                                 : 1.0,
                             onChanged:
-                                (_hasError || _currentDuration <= Duration.zero)
+                                (_hasError || _currentDuration <= Duration.zero || (_availableActions != null && !_availableActions!.contains(MediaAction.seekTo)))
                                     ? null
                                     : (v) {
                                         final newPosition = Duration(
@@ -413,7 +439,7 @@ class _PlayerHomeState extends State<PlayerHome> {
                                         setState(() => _position = newPosition);
                                       },
                             onChangeEnd:
-                                (_hasError || _currentDuration <= Duration.zero)
+                                (_hasError || _currentDuration <= Duration.zero || (_availableActions != null && !_availableActions!.contains(MediaAction.seekTo)))
                                     ? null
                                     : (v) {
                                         final newPosition = Duration(
@@ -454,16 +480,18 @@ class _PlayerHomeState extends State<PlayerHome> {
                   children: [
                     IconButton.filledTonal(
                       iconSize: 32,
-                      onPressed: _prev,
+                      onPressed: (_availableActions != null && !_availableActions!.contains(MediaAction.skipToPrevious)) ? null : _prev,
                       icon: const Icon(Icons.skip_previous),
                     ),
                     IconButton.filled(
                       iconSize: 56,
-                      onPressed: _hasError
-                          ? _play
-                          : (_status == PlaybackStatus.playing
-                              ? _pause
-                              : _play),
+                      onPressed: (_availableActions != null && !_availableActions!.contains(_status == PlaybackStatus.playing ? MediaAction.pause : MediaAction.play))
+                          ? null
+                          : (_hasError
+                              ? _play
+                              : (_status == PlaybackStatus.playing
+                                  ? _pause
+                                  : _play)),
                       icon: Icon(
                         _status == PlaybackStatus.playing
                             ? Icons.pause
@@ -472,7 +500,7 @@ class _PlayerHomeState extends State<PlayerHome> {
                     ),
                     IconButton.filledTonal(
                       iconSize: 32,
-                      onPressed: _next,
+                      onPressed: (_availableActions != null && !_availableActions!.contains(MediaAction.skipToNext)) ? null : _next,
                       icon: const Icon(Icons.skip_next),
                     ),
                   ],
@@ -499,11 +527,93 @@ class _PlayerHomeState extends State<PlayerHome> {
                     },
                   ),
                 ),
+                const SizedBox(height: 32),
+                if (_active) ...[
+                  Text(
+                    "System Control Actions",
+                    style: textTheme.titleMedium,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 8),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    alignment: WrapAlignment.center,
+                    children: [
+                      FilterChip(
+                        label: const Text("All"),
+                        selected: _availableActions == null,
+                        onSelected: (selected) {
+                          if (selected) {
+                            setState(() => _availableActions = null);
+                            _updateAvailableActions();
+                          }
+                        },
+                      ),
+                      for (final action in [
+                        MediaAction.play,
+                        MediaAction.pause,
+                        MediaAction.skipToNext,
+                        MediaAction.skipToPrevious,
+                        MediaAction.seekTo,
+                        MediaAction.stop,
+                        MediaAction.rewind,
+                        MediaAction.fastForward,
+                      ])
+                        _singleActionChip(action),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    "Selected: ${_availableActions == null ? 'All' : _availableActions!.map((a) => a.name).join(', ')}",
+                    style: textTheme.bodySmall,
+                    textAlign: TextAlign.center,
+                  ),
+                ],
               ],
             ),
           ),
         ),
       ),
+    );
+  }
+
+  Widget _singleActionChip(MediaAction action) {
+    final isSelected =
+        _availableActions == null || _availableActions!.contains(action);
+
+    return FilterChip(
+      label: Text(action.name),
+      selected: isSelected,
+      onSelected: (selected) {
+        setState(() {
+          if (_availableActions == null) {
+            if (!selected) {
+              _availableActions = {
+                MediaAction.play,
+                MediaAction.pause,
+                MediaAction.skipToNext,
+                MediaAction.skipToPrevious,
+                MediaAction.seekTo,
+                MediaAction.stop,
+                MediaAction.rewind,
+                MediaAction.fastForward,
+              }..remove(action);
+            }
+          } else {
+            if (selected) {
+              _availableActions!.add(action);
+              if (_availableActions!.length == 8) {
+                // If all 8 standard actions are selected, revert to null (All)
+                _availableActions = null;
+              }
+            } else {
+              _availableActions!.remove(action);
+            }
+          }
+        });
+        _updateAvailableActions();
+      },
     );
   }
 }

--- a/lib/flutter_media_session.dart
+++ b/lib/flutter_media_session.dart
@@ -48,4 +48,22 @@ class FlutterMediaSession {
   Future<void> updatePlaybackState(PlaybackState state) {
     return FlutterMediaSessionPlatform.instance.updatePlaybackState(state);
   }
+
+  /// Updates which media actions are available in system controls.
+  ///
+  /// Actions not in [actions] will be disabled in the notification.
+  /// Pass null to enable all actions (the default).
+  ///
+  /// Example — disable skip buttons:
+  /// ```dart
+  /// await _mediaSession.updateAvailableActions({
+  ///   MediaAction.play,
+  ///   MediaAction.pause,
+  ///   MediaAction.seekTo,
+  ///   MediaAction.stop,
+  /// });
+  /// ```
+  Future<void> updateAvailableActions(Set<MediaAction>? actions) {
+    return FlutterMediaSessionPlatform.instance.updateAvailableActions(actions);
+  }
 }

--- a/lib/flutter_media_session_method_channel.dart
+++ b/lib/flutter_media_session_method_channel.dart
@@ -35,6 +35,14 @@ class MethodChannelFlutterMediaSession extends FlutterMediaSessionPlatform {
   }
 
   @override
+  Future<void> updateAvailableActions(Set<MediaAction>? actions) async {
+    await methodChannel.invokeMethod(
+      'updateAvailableActions',
+      actions?.map((a) => a.name).toList(),
+    );
+  }
+
+  @override
   Stream<MediaAction> get onMediaAction {
     return eventChannel.receiveBroadcastStream().map((event) {
       if (event is Map) {

--- a/lib/flutter_media_session_platform_interface.dart
+++ b/lib/flutter_media_session_platform_interface.dart
@@ -48,6 +48,15 @@ abstract class FlutterMediaSessionPlatform extends PlatformInterface {
     throw UnimplementedError('updatePlaybackState() has not been implemented.');
   }
 
+  /// Updates the set of media actions available in system controls.
+  ///
+  /// Actions not in [actions] will be disabled (hidden or greyed out)
+  /// in the notification and lock screen. Pass null to enable all actions.
+  Future<void> updateAvailableActions(Set<MediaAction>? actions) {
+    throw UnimplementedError(
+        'updateAvailableActions() has not been implemented.');
+  }
+
   /// A stream of media actions emitted by the current platform.
   Stream<MediaAction> get onMediaAction {
     throw UnimplementedError('onMediaAction has not been implemented.');

--- a/lib/flutter_media_session_web.dart
+++ b/lib/flutter_media_session_web.dart
@@ -118,6 +118,35 @@ class FlutterMediaSessionWeb extends FlutterMediaSessionPlatform {
     }
   }
 
+  /// Map from browser action names to MediaAction constants.
+  static const _webActionMap = {
+    'play': MediaAction.play,
+    'pause': MediaAction.pause,
+    'previoustrack': MediaAction.skipToPrevious,
+    'nexttrack': MediaAction.skipToNext,
+    'stop': MediaAction.stop,
+    'seekbackward': MediaAction.rewind,
+    'seekforward': MediaAction.fastForward,
+    'seekto': MediaAction.seekTo,
+  };
+
+  @override
+  Future<void> updateAvailableActions(Set<MediaAction>? actions) async {
+    try {
+      final session = web.window.navigator.mediaSession;
+      for (final entry in _webActionMap.entries) {
+        if (actions == null || actions.contains(entry.value)) {
+          _registerAction(session, entry.key, entry.value);
+        } else {
+          // Unregister by setting handler to null
+          try {
+            session.setActionHandler(entry.key, null);
+          } catch (_) {}
+        }
+      }
+    } catch (_) {}
+  }
+
   /// Internal helper to register a media action handler with the browser's media session.
   void _registerAction(
       web.MediaSession session, String actionName, MediaAction actionToEmit) {

--- a/test/flutter_media_session_test.dart
+++ b/test/flutter_media_session_test.dart
@@ -20,6 +20,10 @@ class MockFlutterMediaSessionPlatform
   Future<void> updatePlaybackState(PlaybackState state) => Future.value();
 
   @override
+  Future<void> updateAvailableActions(Set<MediaAction>? actions) =>
+      Future.value();
+
+  @override
   Stream<MediaAction> get onMediaAction => const Stream.empty();
 }
 

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -62,7 +62,7 @@ set(flutter_media_session_bundled_libraries
 
 # Only enable test builds when building the example (which sets this variable)
 # so that plugin clients aren't building the tests.
-if (FALSE AND ${include_${PROJECT_NAME}_tests})
+if(FALSE)
 set(TEST_RUNNER "${PROJECT_NAME}_test")
 enable_testing()
 

--- a/windows/flutter_media_session_plugin.cpp
+++ b/windows/flutter_media_session_plugin.cpp
@@ -276,11 +276,13 @@ void FlutterMediaSessionPlugin::HandleMethodCall(
               
               if (duration_ms_ > 0) {
                   winrt::Windows::Media::SystemMediaTransportControlsTimelineProperties timelineProperties;
-                  timelineProperties.StartTime(winrt::Windows::Foundation::TimeSpan::zero());
-                  timelineProperties.MinSeekTime(winrt::Windows::Foundation::TimeSpan::zero());
-                  timelineProperties.EndTime(winrt::Windows::Foundation::TimeSpan(duration_ms_ * 10000));
-                  timelineProperties.MaxSeekTime(winrt::Windows::Foundation::TimeSpan(duration_ms_ * 10000));
-                  timelineProperties.Position(winrt::Windows::Foundation::TimeSpan::zero());
+                  if (has_seek_to_) {
+                      timelineProperties.StartTime(winrt::Windows::Foundation::TimeSpan::zero());
+                      timelineProperties.MinSeekTime(winrt::Windows::Foundation::TimeSpan::zero());
+                      timelineProperties.EndTime(winrt::Windows::Foundation::TimeSpan(duration_ms_ * 10000));
+                      timelineProperties.MaxSeekTime(winrt::Windows::Foundation::TimeSpan(duration_ms_ * 10000));
+                      timelineProperties.Position(winrt::Windows::Foundation::TimeSpan::zero());
+                  }
                   smtc_.UpdateTimelineProperties(timelineProperties);
               }
           } catch (winrt::hresult_error const& ex) {
@@ -321,17 +323,70 @@ void FlutterMediaSessionPlugin::HandleMethodCall(
                   if (pos_ms >= 0 && duration_ms_ > 0) {
                       try {
                           winrt::Windows::Media::SystemMediaTransportControlsTimelineProperties timelineProperties;
-                          timelineProperties.StartTime(winrt::Windows::Foundation::TimeSpan::zero());
-                          timelineProperties.MinSeekTime(winrt::Windows::Foundation::TimeSpan::zero());
-                          timelineProperties.EndTime(winrt::Windows::Foundation::TimeSpan(duration_ms_ * 10000)); // 100ns units
-                          timelineProperties.MaxSeekTime(winrt::Windows::Foundation::TimeSpan(duration_ms_ * 10000));
-                          timelineProperties.Position(winrt::Windows::Foundation::TimeSpan(pos_ms * 10000));
+                          if (has_seek_to_) {
+                              timelineProperties.StartTime(winrt::Windows::Foundation::TimeSpan::zero());
+                              timelineProperties.MinSeekTime(winrt::Windows::Foundation::TimeSpan::zero());
+                              timelineProperties.EndTime(winrt::Windows::Foundation::TimeSpan(duration_ms_ * 10000)); // 100ns units
+                              timelineProperties.MaxSeekTime(winrt::Windows::Foundation::TimeSpan(duration_ms_ * 10000));
+                              timelineProperties.Position(winrt::Windows::Foundation::TimeSpan(pos_ms * 10000));
+                          }
                           smtc_.UpdateTimelineProperties(timelineProperties);
                       } catch (winrt::hresult_error const& ex) {
                           OutputDebugStringW((L"SMTC TimelineProperties update error: " + ex.message() + L"\n").c_str());
                       }
                   }
               }
+          }
+      }
+      result->Success();
+  } else if (method_name == "updateAvailableActions") {
+      if (smtc_) {
+          const auto* actions = std::get_if<flutter::EncodableList>(method_call.arguments());
+          if (actions) {
+              // Check which actions are in the list
+              bool hasPlay = false, hasPause = false, hasNext = false, hasPrevious = false;
+              bool hasStop = false, hasFastForward = false, hasRewind = false;
+              has_seek_to_ = false;
+              for (const auto& action : *actions) {
+                  if (auto str = std::get_if<std::string>(&action)) {
+                      if (*str == "play") hasPlay = true;
+                      else if (*str == "pause") hasPause = true;
+                      else if (*str == "skipToNext") hasNext = true;
+                      else if (*str == "skipToPrevious") hasPrevious = true;
+                      else if (*str == "stop") hasStop = true;
+                      else if (*str == "fastForward") hasFastForward = true;
+                      else if (*str == "rewind") hasRewind = true;
+                      else if (*str == "seekTo") has_seek_to_ = true;
+                  }
+              }
+              try {
+                  smtc_.IsPlayEnabled(hasPlay);
+                  smtc_.IsPauseEnabled(hasPause);
+                  smtc_.IsNextEnabled(hasNext);
+                  smtc_.IsPreviousEnabled(hasPrevious);
+                  smtc_.IsStopEnabled(hasStop);
+                  smtc_.IsFastForwardEnabled(hasFastForward);
+                  smtc_.IsRewindEnabled(hasRewind);
+                  
+                  if (!has_seek_to_) {
+                      winrt::Windows::Media::SystemMediaTransportControlsTimelineProperties timelineProperties;
+                      smtc_.UpdateTimelineProperties(timelineProperties);
+                  }
+              } catch (winrt::hresult_error const& ex) {
+                  OutputDebugStringW((L"SMTC updateAvailableActions error: " + ex.message() + L"\n").c_str());
+              }
+          } else {
+              // null = enable all
+              has_seek_to_ = true;
+              try {
+                  smtc_.IsPlayEnabled(true);
+                  smtc_.IsPauseEnabled(true);
+                  smtc_.IsNextEnabled(true);
+                  smtc_.IsPreviousEnabled(true);
+                  smtc_.IsStopEnabled(true);
+                  smtc_.IsFastForwardEnabled(true);
+                  smtc_.IsRewindEnabled(true);
+              } catch (...) {}
           }
       }
       result->Success();

--- a/windows/flutter_media_session_plugin.h
+++ b/windows/flutter_media_session_plugin.h
@@ -89,6 +89,7 @@ private:
   void DisposeSmtc();
 
   int64_t duration_ms_ = 0;
+  bool has_seek_to_ = true;
 };
 
 } // namespace flutter_media_session


### PR DESCRIPTION
## Overview
This PR improves and completes functionality from PR #2 (not merged yet), providing dynamic control of media actions (play, pause, skip, seek, etc.) across Android, Windows, and Web platforms. Developers can now customize available player actions based on the current track's permissions or app state.

## Key Changes

### Core API
- Added `updateAvailableActions(Set<MediaAction>? actions)` to `FlutterMediaSession`.
- Passing `null` restores all default actions.

### Android
- Updated `FlutterMediaSessionService` to use a dynamic `Player.Commands` builder in `ForwardingPlayer`.
- Correctly hides or disables specific buttons in the Android notification and lock screen.

### Windows
- Implemented SMTC (System Media Transport Controls) toggles for:
  - Play
  - Pause
  - Next
  - Previous
  - Stop
  - FastForward
  - Rewind
- **Seek Bar Lock**: When `seekTo` is disabled, SMTC timeline properties are cleared to hide/disable the progress bar.

### Web
- Implemented dynamic registration/unregistration of MediaSession action handlers.

### Example App
- Added a **"System Control Actions"** section with interactive chips for testing each action individually.
- Improved robustness by handling browser `AbortError` during rapid play/pause transitions.
- Synced example UI buttons (play/pause/prev/next/slider) to reflect the `availableActions` state.

### Notes
- Supersedes PR #2, consolidating all previous functionality and improvements.