### PR TITLE
Suggestion: opt-in audio focus / interruption handling on Android (#12)

### DIFF
--- a/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionPlugin.kt
+++ b/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionPlugin.kt
@@ -34,6 +34,15 @@ class FlutterMediaSessionPlugin: FlutterPlugin, MethodCallHandler, ActivityAware
     private var pendingMetadata: Map<String, Any?>? = null
     private var pendingPlaybackState: Map<String, Any?>? = null
     private var pendingAvailableActions: List<String>? = null
+    /**
+     * When true, the service requests audio focus while playing and forwards
+     * focus events as media actions. Mirrors the user-facing
+     * `setHandlesInterruptions` API; defaults to false so we don't fight other
+     * audio plugins (audioplayers, just_audio) that already manage focus.
+     * Persisted across service restarts so the setting survives deactivate.
+     */
+    var handlesInterruptions: Boolean = false
+        private set
 
     companion object {
         private const val REQUEST_NOTIFICATION_PERMISSION = 1101
@@ -113,6 +122,12 @@ class FlutterMediaSessionPlugin: FlutterPlugin, MethodCallHandler, ActivityAware
             }
             "requestNotificationPermission" -> {
                 requestNotificationPermission(result)
+            }
+            "setHandlesInterruptions" -> {
+                val enabled = call.arguments as? Boolean ?: false
+                handlesInterruptions = enabled
+                FlutterMediaSessionService.instance?.onHandlesInterruptionsChanged(enabled)
+                result.success(null)
             }
             else -> result.notImplemented()
         }

--- a/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionService.kt
+++ b/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionService.kt
@@ -134,7 +134,23 @@ class FlutterMediaSessionService : MediaSessionService() {
             audioManager.abandonAudioFocus(audioFocusListener)
         }
         hasAudioFocus = false
-        resumeOnFocusGain = false
+        // Note: do NOT reset resumeOnFocusGain here. abandonAudioFocus() runs
+        // after we've already sent "pause" to Flutter on a transient loss,
+        // and the next "paused" status update from Flutter will trip this.
+        // We need the flag preserved so AUDIOFOCUS_GAIN can resume.
+    }
+
+    /**
+     * Called by the plugin when the user toggles `setHandlesInterruptions`.
+     * If turning off, drops any focus we currently hold so other audio
+     * plugins (audioplayers, just_audio) can take it back without
+     * fighting us.
+     */
+    fun onHandlesInterruptionsChanged(enabled: Boolean) {
+        if (!enabled) {
+            abandonAudioFocus()
+            resumeOnFocusGain = false
+        }
     }
 
     override fun onCreate() {
@@ -276,12 +292,15 @@ class FlutterMediaSessionService : MediaSessionService() {
                 isReceiverRegistered = false
             }
 
-            // Manage audio focus alongside the noisy receiver. Hold focus while
-            // playing so the system routes call/navigation interruptions to us.
-            if (isPlaying) {
-                requestAudioFocus()
-            } else if (status != "buffering") {
-                abandonAudioFocus()
+            // Manage audio focus alongside the noisy receiver, but only if the
+            // user opted in. By default we stay out of the focus race so apps
+            // that already manage focus (audioplayers, just_audio) keep working.
+            if (FlutterMediaSessionPlugin.instance?.handlesInterruptions == true) {
+                if (isPlaying) {
+                    requestAudioFocus()
+                } else if (status != "buffering") {
+                    abandonAudioFocus()
+                }
             }
         }
 

--- a/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionService.kt
+++ b/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionService.kt
@@ -1,7 +1,11 @@
 package dev.wyrin.flutter_media_session
 
 import android.app.PendingIntent
+import android.content.Context
 import android.content.Intent
+import android.media.AudioFocusRequest
+import android.media.AudioManager
+import android.os.Build
 import android.os.Bundle
 import androidx.annotation.OptIn
 import androidx.media3.common.AudioAttributes
@@ -36,17 +40,101 @@ class FlutterMediaSessionService : MediaSessionService() {
 
     private var isReceiverRegistered = false
 
+    private val audioManager: AudioManager by lazy {
+        getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    }
+    private var audioFocusRequest: AudioFocusRequest? = null
+    private var hasAudioFocus = false
+    /**
+     * Set when we lose focus transiently (e.g. an incoming call) while playing,
+     * so we can ask the Flutter side to resume once focus returns. Permanent
+     * losses do not set this — the user gave focus to another app on purpose.
+     */
+    private var resumeOnFocusGain = false
+
     /**
      * BroadcastReceiver to handle ACTION_AUDIO_BECOMING_NOISY, which typically happens
      * when headphones are unplugged. It notifies the Flutter side to pause playback.
      */
     private val noisyReceiver = object : android.content.BroadcastReceiver() {
         override fun onReceive(context: android.content.Context, intent: android.content.Intent) {
-            if (android.media.AudioManager.ACTION_AUDIO_BECOMING_NOISY == intent.action) {
+            if (AudioManager.ACTION_AUDIO_BECOMING_NOISY == intent.action) {
                 // Notify Flutter side to pause playback
                 FlutterMediaSessionPlugin.instance?.sendAction("pause")
             }
         }
+    }
+
+    /**
+     * Listens for audio focus changes (e.g. phone calls, navigation prompts).
+     * Permanent and transient losses both ask Flutter to pause; transient losses
+     * additionally trigger a resume when focus returns. Duckable losses are left
+     * to the system to handle by lowering the volume automatically.
+     */
+    private val audioFocusListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
+        when (focusChange) {
+            AudioManager.AUDIOFOCUS_LOSS -> {
+                hasAudioFocus = false
+                resumeOnFocusGain = false
+                FlutterMediaSessionPlugin.instance?.sendAction("pause")
+            }
+            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
+                resumeOnFocusGain = hasAudioFocus
+                hasAudioFocus = false
+                FlutterMediaSessionPlugin.instance?.sendAction("pause")
+            }
+            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> {
+                // No-op: the system ducks playback volume automatically because
+                // willPauseWhenDucked is false on the focus request.
+            }
+            AudioManager.AUDIOFOCUS_GAIN -> {
+                hasAudioFocus = true
+                if (resumeOnFocusGain) {
+                    resumeOnFocusGain = false
+                    FlutterMediaSessionPlugin.instance?.sendAction("play")
+                }
+            }
+        }
+    }
+
+    private fun requestAudioFocus() {
+        if (hasAudioFocus) return
+        val granted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val request = audioFocusRequest ?: AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+                .setAudioAttributes(
+                    android.media.AudioAttributes.Builder()
+                        .setUsage(android.media.AudioAttributes.USAGE_MEDIA)
+                        .setContentType(android.media.AudioAttributes.CONTENT_TYPE_MUSIC)
+                        .build()
+                )
+                .setOnAudioFocusChangeListener(audioFocusListener)
+                .setWillPauseWhenDucked(false)
+                .build()
+                .also { audioFocusRequest = it }
+            audioManager.requestAudioFocus(request) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        } else {
+            @Suppress("DEPRECATION")
+            audioManager.requestAudioFocus(
+                audioFocusListener,
+                AudioManager.STREAM_MUSIC,
+                AudioManager.AUDIOFOCUS_GAIN
+            ) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        }
+        if (granted) {
+            hasAudioFocus = true
+        }
+    }
+
+    private fun abandonAudioFocus() {
+        if (!hasAudioFocus && audioFocusRequest == null) return
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            audioFocusRequest?.let { audioManager.abandonAudioFocusRequest(it) }
+        } else {
+            @Suppress("DEPRECATION")
+            audioManager.abandonAudioFocus(audioFocusListener)
+        }
+        hasAudioFocus = false
+        resumeOnFocusGain = false
     }
 
     override fun onCreate() {
@@ -85,6 +173,7 @@ class FlutterMediaSessionService : MediaSessionService() {
             unregisterReceiver(noisyReceiver)
             isReceiverRegistered = false
         }
+        abandonAudioFocus()
         mediaSession?.run {
             player.release()
             release()
@@ -180,11 +269,19 @@ class FlutterMediaSessionService : MediaSessionService() {
 
             // Manage AudioBecomingNoisy receiver based on playback state
             if (isPlaying && !isReceiverRegistered) {
-                registerReceiver(noisyReceiver, android.content.IntentFilter(android.media.AudioManager.ACTION_AUDIO_BECOMING_NOISY))
+                registerReceiver(noisyReceiver, android.content.IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY))
                 isReceiverRegistered = true
             } else if (!isPlaying && isReceiverRegistered) {
                 unregisterReceiver(noisyReceiver)
                 isReceiverRegistered = false
+            }
+
+            // Manage audio focus alongside the noisy receiver. Hold focus while
+            // playing so the system routes call/navigation interruptions to us.
+            if (isPlaying) {
+                requestAudioFocus()
+            } else if (status != "buffering") {
+                abandonAudioFocus()
             }
         }
 

--- a/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionService.kt
+++ b/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionService.kt
@@ -150,6 +150,9 @@ class FlutterMediaSessionService : MediaSessionService() {
         if (!enabled) {
             abandonAudioFocus()
             resumeOnFocusGain = false
+        } else if (player.playbackStatus == "playing") {
+            // If enabled while already playing, request focus immediately.
+            requestAudioFocus()
         }
     }
 
@@ -298,7 +301,10 @@ class FlutterMediaSessionService : MediaSessionService() {
             if (FlutterMediaSessionPlugin.instance?.handlesInterruptions == true) {
                 if (isPlaying) {
                     requestAudioFocus()
-                } else if (status != "buffering") {
+                } else if (status != "buffering" && !resumeOnFocusGain) {
+                    // Only abandon focus if we're not waiting to resume from a transient loss.
+                    // Abandoning focus removes the app from the focus stack, which would
+                    // prevent us from ever receiving AUDIOFOCUS_GAIN back.
                     abandonAudioFocus()
                 }
             }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -52,6 +52,7 @@ class _PlayerHomeState extends State<PlayerHome> {
   bool _active = false;
   PlaybackStatus _status = PlaybackStatus.idle;
   bool _isBuffering = false;
+  bool _handlesInterruptions = false;
   bool _hasError = false;
   bool _isSwitchingTrack = false;
   int _currentIndex = 0;
@@ -203,6 +204,7 @@ class _PlayerHomeState extends State<PlayerHome> {
       _isBuffering = false;
       _position = Duration.zero;
       _isSwitchingTrack = false;
+      _handlesInterruptions = false; // Reset on deactivate
     });
   }
 
@@ -570,17 +572,30 @@ class _PlayerHomeState extends State<PlayerHome> {
                     ],
                   ),
                   const SizedBox(height: 16),
-                  Text(
-                    "Selected: ${_availableActions == null ? 'All' : _availableActions!.map((a) => a.name).join(', ')}",
-                    style: textTheme.bodySmall,
-                    textAlign: TextAlign.center,
-                  ),
+                    Text(
+                      "Selected: ${_availableActions == null ? 'All' : _availableActions!.map((a) => a.name).join(', ')}",
+                      style: textTheme.bodySmall,
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 24),
+                    const Divider(),
+                    const SizedBox(height: 16),
+                    SwitchListTile(
+                      title: const Text("Handle Audio Focus"),
+                      subtitle: const Text(
+                          "Opt-in to Android audio focus management (pauses for calls/other apps)"),
+                      value: _handlesInterruptions,
+                      onChanged: (val) {
+                        setState(() => _handlesInterruptions = val);
+                        _plugin.setHandlesInterruptions(val);
+                      },
+                    ),
+                  ],
                 ],
-              ],
+              ),
             ),
           ),
         ),
-      ),
     );
   }
 

--- a/lib/flutter_media_session.dart
+++ b/lib/flutter_media_session.dart
@@ -73,4 +73,21 @@ class FlutterMediaSession {
   Future<bool> requestNotificationPermission() {
     return FlutterMediaSessionPlatform.instance.requestNotificationPermission();
   }
+
+  /// Opts the plugin into handling system audio interruptions
+  /// (calls, navigation prompts, other apps grabbing audio).
+  ///
+  /// When enabled, the plugin requests audio focus on Android while
+  /// playback is `playing` and forwards focus events through
+  /// [onMediaAction] — `pause` on focus loss, `play` when transient
+  /// focus returns. Defaults to `false`.
+  ///
+  /// Leave this off if your audio player already manages focus
+  /// (e.g. `audioplayers`, `just_audio`), otherwise both will fight
+  /// for it and silently pause each other. Turn it on for players
+  /// that don't manage focus themselves (e.g. `fvp`, `video_player`).
+  Future<void> setHandlesInterruptions(bool enabled) {
+    return FlutterMediaSessionPlatform.instance
+        .setHandlesInterruptions(enabled);
+  }
 }

--- a/lib/flutter_media_session_method_channel.dart
+++ b/lib/flutter_media_session_method_channel.dart
@@ -50,6 +50,11 @@ class MethodChannelFlutterMediaSession extends FlutterMediaSessionPlatform {
   }
 
   @override
+  Future<void> setHandlesInterruptions(bool enabled) async {
+    await methodChannel.invokeMethod('setHandlesInterruptions', enabled);
+  }
+
+  @override
   Stream<MediaAction> get onMediaAction {
     return eventChannel.receiveBroadcastStream().map((event) {
       if (event is Map) {

--- a/lib/flutter_media_session_platform_interface.dart
+++ b/lib/flutter_media_session_platform_interface.dart
@@ -65,6 +65,23 @@ abstract class FlutterMediaSessionPlatform extends PlatformInterface {
         'requestNotificationPermission() has not been implemented.');
   }
 
+  /// Opts the plugin into handling system audio interruptions
+  /// (calls, navigation prompts, other apps grabbing audio).
+  ///
+  /// When enabled, the plugin requests audio focus on Android while
+  /// playback is `playing`, and forwards focus events to your app via
+  /// the existing [onMediaAction] stream — `pause` on a loss, `play`
+  /// when transient focus returns. Defaults to `false`.
+  ///
+  /// Leave this off if your audio player already manages focus
+  /// (e.g. `audioplayers`, `just_audio`), otherwise both will fight
+  /// for it and silently pause each other. Turn it on for players
+  /// that don't manage focus themselves (e.g. `fvp`, `video_player`).
+  Future<void> setHandlesInterruptions(bool enabled) {
+    throw UnimplementedError(
+        'setHandlesInterruptions() has not been implemented.');
+  }
+
   /// A stream of media actions emitted by the current platform.
   Stream<MediaAction> get onMediaAction {
     throw UnimplementedError('onMediaAction has not been implemented.');

--- a/lib/flutter_media_session_web.dart
+++ b/lib/flutter_media_session_web.dart
@@ -152,6 +152,12 @@ class FlutterMediaSessionWeb extends FlutterMediaSessionPlatform {
     return true;
   }
 
+  @override
+  Future<void> setHandlesInterruptions(bool enabled) async {
+    // No-op on web: browsers don't expose audio-focus-style interruption
+    // events, and the page is typically the only audio source.
+  }
+
   /// Internal helper to register a media action handler with the browser's media session.
   void _registerAction(
       web.MediaSession session, String actionName, MediaAction actionToEmit) {

--- a/test/flutter_media_session_test.dart
+++ b/test/flutter_media_session_test.dart
@@ -27,6 +27,9 @@ class MockFlutterMediaSessionPlatform
   Future<bool> requestNotificationPermission() => Future.value(true);
 
   @override
+  Future<void> setHandlesInterruptions(bool enabled) => Future.value();
+
+  @override
   Stream<MediaAction> get onMediaAction => const Stream.empty();
 }
 

--- a/windows/flutter_media_session_plugin.cpp
+++ b/windows/flutter_media_session_plugin.cpp
@@ -390,6 +390,9 @@ void FlutterMediaSessionPlugin::HandleMethodCall(
           }
       }
       result->Success();
+  } else if (method_name == "setHandlesInterruptions") {
+      // No-op on Windows: SMTC manages session focus implicitly.
+      result->Success();
   } else {
       result->NotImplemented();
   }


### PR DESCRIPTION
## TL;DR — this is a suggestion, not a final design

Closes #12 with a minimal, opt-in surface: `setHandlesInterruptions(bool)`. Default off. Happy to change direction based on your preference.

## Why opt-in (not always-on)

I started with always-on focus. Testing on a real Android emulator with `audioplayers` revealed the trap:

- `audioplayers` already requests audio focus when it plays.
- Our plugin requesting focus too → `audioplayers` got `AUDIOFOCUS_LOSS` → silently paused its underlying media player.
- The plugin's state still said `playing`, so the user's UI was out of sync with what they actually heard (silent).

Same situation applies to `just_audio` and `video_player` (uses ExoPlayer with `handleAudioFocus = true` by default — confirmed in `video_player_android-2.9.1/.../VideoPlayer.java:91-93`).

## When the opt-in is useful

Players that **don't** manage focus themselves:

- `fvp` (libmdk-ffmpeg)
- `flutter_vlc_player` (libVLC)
- Custom native players via platform channels
- Anything that doesn't go through ExoPlayer / AVPlayer's built-in focus

For those, the user previously had no way to make a phone call pause their app. Now they can:

```dart
await mediaSession.setHandlesInterruptions(true);
```

## Behaviour when enabled

- Hold focus while status is `playing`; abandon on `paused`/`idle`/`stopped`.
- `AUDIOFOCUS_LOSS` (permanent — another media app started) → send `pause` to Dart, no auto-resume.
- `AUDIOFOCUS_LOSS_TRANSIENT` (call coming in) → send `pause`, remember we were playing.
- `AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK` (nav prompt) → no-op; system ducks volume.
- `AUDIOFOCUS_GAIN` after a transient loss → send `play` so the call/nav prompt cleanly hands playback back.

All routed through the same `MediaAction` events the app already handles for system controls — no new event types.

## Verified on emulator (Android 16)

Inspected `MediaFocusControl` logs:
- With opt-in **off**: plugin doesn't touch focus, `audioplayers` works as before.
- With opt-in **on**: plugin's focus request granted with `USAGE_MEDIA/CONTENT_TYPE_MUSIC`, abandon on pause.
- Phone call simulated via `adb emu gsm call`: telecom takes focus → our listener gets `AUDIOFOCUS_LOSS_TRANSIENT(-2)` → app pauses. Bug fixed in this commit also restores auto-resume on `AUDIOFOCUS_GAIN`.

## Alternatives considered (and why I didn't pick them)

- **Always-on focus** — breaks `audioplayers` / `just_audio` users by displacing their focus.
- **Listen-only (no request)** — Android doesn't expose this. `OnAudioFocusChangeListener` only fires for the focus owner.
- **`TelephonyManager.PhoneStateListener`** — works without focus, but only for calls, not other interruptions; also requires READ_PHONE_STATE on some OEMs.
- **Recommend `audio_session` instead** — also reasonable. The opt-in here keeps the package self-contained for users who want one dependency.

## Open questions for the maintainer

1. **Naming**: `setHandlesInterruptions` vs `setManageAudioFocus` vs an `activate(handlesInterruptions: true)` parameter. I went with the verbose name to leave room for iOS interruption notifications later.
2. **Default**: would you prefer it to default to `true` and let problematic players opt out, or stay opt-in like this?
3. **Scope**: keep this as Android-only for now, or wait until iOS/macOS implementations land (PR #13) and ship them together?

Happy to rework any of the above before merge.

## Files changed

- `android/.../FlutterMediaSessionService.kt` — focus request/abandon, listener, lifecycle.
- `android/.../FlutterMediaSessionPlugin.kt` — flag + method handler.
- `lib/flutter_media_session.dart`, platform interface, method channel, web — Dart API + no-ops.
- `windows/flutter_media_session_plugin.cpp` — no-op handler so the call doesn't throw `MissingPluginException` on Windows.

## Test plan

- [x] Plugin compiles (`flutter build apk`).
- [x] Verified on Android 16 emulator: focus is requested/abandoned only when opt-in is on; phone-call simulation pauses Dart side and resumes after call.
- [ ] Manual on real device: phone call → app pauses, end call → app resumes.
- [ ] Manual on real device: nav prompt during playback → audio ducks, no pause.
- [ ] Manual: `audioplayers` still works correctly with opt-in **off** (no regression).

Closes #12.