### PR TITLE
fix(android): expose playback state via accessor for outer service

### DIFF
--- a/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionService.kt
+++ b/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionService.kt
@@ -150,7 +150,7 @@ class FlutterMediaSessionService : MediaSessionService() {
         if (!enabled) {
             abandonAudioFocus()
             resumeOnFocusGain = false
-        } else if (player.playbackStatus == "playing") {
+        } else if (player.isCurrentlyPlaying()) {
             // If enabled while already playing, request focus immediately.
             requestAudioFocus()
         }
@@ -240,6 +240,11 @@ class FlutterMediaSessionService : MediaSessionService() {
     inner class ForwardingPlayer : androidx.media3.common.SimpleBasePlayer(mainLooper) {
         private var currentMetadata: MediaMetadata = MediaMetadata.EMPTY
         private var playbackStatus: String = "buffering"
+
+        /** Outer-class accessor — `playbackStatus` is private to this inner
+         *  class so [FlutterMediaSessionService.onHandlesInterruptionsChanged]
+         *  cannot read the field directly. */
+        fun isCurrentlyPlaying(): Boolean = playbackStatus == "playing"
         private var lastPositionMs: Long = 0
         private var lastPositionUpdateTimeMs: Long = android.os.SystemClock.elapsedRealtime()
         private var speed: Float = 1.0f


### PR DESCRIPTION
## Summary

Building against the current `main` (commit `430537a`) fails with:

\`\`\`
e: FlutterMediaSessionService.kt:153:27
Cannot access 'var playbackStatus: String':
it is private in 'dev/wyrin/flutter_media_session/FlutterMediaSessionService.ForwardingPlayer'.
\`\`\`

\`onHandlesInterruptionsChanged\` (introduced in #14) reads \`player.playbackStatus\` from the outer service class, but \`playbackStatus\` is declared \`private var\` inside the inner \`ForwardingPlayer\`. Kotlin's \`private\` modifier is class-scoped, not file/outer-scoped, so the outer class can't see it.

Add a small \`isCurrentlyPlaying()\` accessor on \`ForwardingPlayer\` and call it from \`onHandlesInterruptionsChanged\` instead of touching the field directly. No public API change.

## Test plan

- [x] \`./gradlew :flutter_media_session:compileReleaseKotlin\` (downstream app build) — passes after the fix
- [ ] Existing example app smoke test still works