### PR TITLE
fix(android): resolve ForegroundService start exceptions and example app crashes

### DIFF
--- a/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionPlugin.kt
+++ b/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionPlugin.kt
@@ -34,6 +34,7 @@ class FlutterMediaSessionPlugin: FlutterPlugin, MethodCallHandler, ActivityAware
     private var pendingMetadata: Map<String, Any?>? = null
     private var pendingPlaybackState: Map<String, Any?>? = null
     private var pendingAvailableActions: List<Any>? = null
+    private var pendingActivateResult: Result? = null
     /**
      * When true, the service requests audio focus while playing and forwards
      * focus events as media actions. Mirrors the user-facing
@@ -71,15 +72,36 @@ class FlutterMediaSessionPlugin: FlutterPlugin, MethodCallHandler, ActivityAware
         })
     }
 
+    private var serviceConnection: android.content.ServiceConnection? = null
+
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
         when (call.method) {
             "activate" -> {
-                val intent = Intent(context, FlutterMediaSessionService::class.java)
-                ContextCompat.startForegroundService(context, intent)
-                result.success(null)
+                if (FlutterMediaSessionService.instance != null) {
+                    result.success(null)
+                } else {
+                    pendingActivateResult = result
+                    val intent = Intent(context, FlutterMediaSessionService::class.java)
+                    serviceConnection = object : android.content.ServiceConnection {
+                        override fun onServiceConnected(name: android.content.ComponentName?, service: android.os.IBinder?) {}
+                        override fun onServiceDisconnected(name: android.content.ComponentName?) {
+                            serviceConnection = null
+                        }
+                    }
+                    try {
+                        context.bindService(intent, serviceConnection!!, Context.BIND_AUTO_CREATE)
+                    } catch (e: Exception) {
+                        pendingActivateResult?.error("SERVICE_ERROR", "Failed to bind service: ${e.message}", null)
+                        pendingActivateResult = null
+                    }
+                }
             }
             "deactivate" -> {
                 val intent = Intent(context, FlutterMediaSessionService::class.java)
+                serviceConnection?.let {
+                    try { context.unbindService(it) } catch (e: Exception) {}
+                    serviceConnection = null
+                }
                 context.stopService(intent)
                 result.success(null)
             }
@@ -200,6 +222,14 @@ class FlutterMediaSessionPlugin: FlutterPlugin, MethodCallHandler, ActivityAware
                 eventSink?.success(action)
             }
         }
+    }
+
+    /**
+     * Called when the MediaSessionService has finished creating and is ready.
+     */
+    fun onServiceCreated() {
+        pendingActivateResult?.success(null)
+        pendingActivateResult = null
     }
 
     /**

--- a/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionService.kt
+++ b/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionService.kt
@@ -187,6 +187,7 @@ class FlutterMediaSessionService : MediaSessionService() {
 
         // Sync any data that was sent to the plugin before the service was ready
         FlutterMediaSessionPlugin.instance?.syncPendingData()
+        FlutterMediaSessionPlugin.instance?.onServiceCreated()
     }
 
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? {
@@ -200,9 +201,10 @@ class FlutterMediaSessionService : MediaSessionService() {
             isReceiverRegistered = false
         }
         abandonAudioFocus()
-        mediaSession?.run {
+        mediaSession?.let {
+            removeSession(it)
             player.release()
-            release()
+            it.release()
             mediaSession = null
         }
         super.onDestroy()

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -67,6 +67,7 @@ class _PlayerHomeState extends State<PlayerHome> {
   bool _hasError = false;
   bool _isSwitchingTrack = false;
   int _currentIndex = 0;
+  int _trackVersion = 0;
   Duration _position = Duration.zero;
   Duration _currentDuration = Duration.zero;
   bool _isLiked = false;
@@ -234,9 +235,12 @@ class _PlayerHomeState extends State<PlayerHome> {
       );
     }
     await _plugin.activate();
+    if (!mounted) return;
     setState(() => _active = true);
-    await _updateAvailableActions();
-    await _updateAll();
+    await Future.wait([
+      _updateAvailableActions(),
+      _updateAll(),
+    ]);
   }
 
   Future<void> _updateAvailableActions() async {
@@ -308,6 +312,7 @@ class _PlayerHomeState extends State<PlayerHome> {
     await _audioPlayer.stop().catchError((_) {});
     setState(() {
       _isSwitchingTrack = true;
+      _trackVersion++;
       _currentIndex =
           (_currentIndex + step + _playlist.length) % _playlist.length;
       _position = Duration.zero;
@@ -417,12 +422,12 @@ class _PlayerHomeState extends State<PlayerHome> {
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 Center(
-                  child: AnimatedSwitcher(
-                    duration: const Duration(milliseconds: 500),
-                    child: Card(
-                      key: ValueKey(track.artwork),
-                      elevation: 8,
-                      shape: RoundedRectangleBorder(
+                    child: AnimatedSwitcher(
+                      duration: const Duration(milliseconds: 500),
+                      child: Card(
+                        key: ValueKey('${track.artwork}_$_trackVersion'),
+                        elevation: 8,
+                        shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(24),
                       ),
                       clipBehavior: Clip.antiAlias,
@@ -477,16 +482,19 @@ class _PlayerHomeState extends State<PlayerHome> {
                             borderRadius: BorderRadius.circular(6.0),
                           ),
                         )
-                      : SliderTheme(
-                          data: SliderTheme.of(context).copyWith(
-                            trackHeight: 12,
-                            padding: EdgeInsets.zero,
-                            overlayShape: SliderComponentShape.noOverlay,
-                            thumbShape: const RoundSliderThumbShape(
-                              enabledThumbRadius: 8.0,
-                            ),
-                          ),
-                          child: Slider(
+                      : LayoutBuilder(
+                          builder: (context, constraints) {
+                            if (constraints.maxWidth <= 0) return const SizedBox.shrink();
+                            return SliderTheme(
+                              data: SliderTheme.of(context).copyWith(
+                                trackHeight: 12,
+                                padding: EdgeInsets.zero,
+                                overlayShape: SliderComponentShape.noOverlay,
+                                thumbShape: const RoundSliderThumbShape(
+                                  enabledThumbRadius: 8.0,
+                                ),
+                              ),
+                              child: Slider(
                             value: _position.inMilliseconds.toDouble().clamp(
                                   0.0,
                                   _currentDuration.inMilliseconds.toDouble() > 0
@@ -530,7 +538,9 @@ class _PlayerHomeState extends State<PlayerHome> {
                                     _updatePlayback();
                                   },
                           ),
-                        ),
+                        );
+                      },
+                    ),
                 ),
                 Padding(
                   padding: const EdgeInsets.symmetric(

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -5,23 +5,16 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:flutter_media_session_example/main.dart';
 
 void main() {
-  testWidgets('Verify Platform version', (WidgetTester tester) async {
+  testWidgets('Verify Player UI', (WidgetTester tester) async {
     // Build our app and trigger a frame.
     await tester.pumpWidget(const MyApp());
 
-    // Verify that platform version is retrieved.
-    expect(
-      find.byWidgetPredicate(
-        (Widget widget) =>
-            widget is Text && widget.data!.startsWith('Running on:'),
-      ),
-      findsOneWidget,
-    );
+    // Verify that the player UI is rendered.
+    expect(find.text('MD3 Player'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Description
This PR resolves a critical asynchronous crash (`ForegroundServiceDidNotStartInTimeException`) on Android, fixes UI rendering exceptions in the example app during edge cases (such as scrolling screenshots), and cleans up potential memory/state leaks during service destruction.

Fixes #18 

## Changes

### 1. Android Service Lifecycle Robustness (Plugin)
* **Replaced `startForegroundService` with `bindService`**: 
  Previously, calling `ContextCompat.startForegroundService` forced the Android OS to mandate a `startForeground()` call within 5 seconds. Since Media3's `MediaSessionService` intelligently manages its own foreground state (only promoting itself when playback actively starts), this led to an unavoidable crash (`ForegroundServiceDidNotStartInTimeException`) if the user activated the session but didn't immediately play media. By using `bindService(Context.BIND_AUTO_CREATE)`, the service starts safely, bypasses Android 8+ background execution limits, and elegantly delegates foreground promotion to Media3.
* **Fixed MethodChannel Race Conditions**: 
  The Dart `activate()` call now accurately waits until `FlutterMediaSessionService.onCreate()` finishes and the internal instance is ready before resolving the `Future`. This prevents the Dart side from bombarding the Android main thread with `updateAvailableActions` and `updateAll` before the service is fully bound.
* **Session Cleanup**: 
  Added `removeSession()` in `FlutterMediaSessionService.onDestroy()` to properly unregister the session from Media3 before releasing it, preventing "ghost" sessions if the app terminates abnormally.

### 2. Example App Stability
* **Fixed `AnimatedSwitcher` Duplicate Keys Crash**: 
  Rapidly cycling through the playlist could cause the `AnimatedSwitcher` to inject the same `track.artwork` key into the widget tree before the fade-out animation completed, triggering a `Duplicate keys found` assertion error (Red Screen). Fixed by appending a monotonic `_trackVersion` counter to the `ValueKey`.
* **Fixed `Slider` Zero-Width Constraints Crash**: 
  Wrapped the `Slider` within a `LayoutBuilder`. When the framework attempts to render the widget off-screen or during a scrolling screenshot (where `constraints.maxWidth` equals `0.0`), the widget gracefully returns a `SizedBox.shrink()` instead of crashing the app with a `Slider` geometry assertion error.

## How to Test
* Repeatedly stress-tested playback and action toggles.
* Performed rapid track switching (next/prev) to confirm UI animations remain stable without duplicate key assertions.
* Successfully generated scrolling screenshots without triggering `Slider` width assertions.
* Confirmed Android session safely stays active and updates system UI without throwing `ForegroundServiceDidNotStartInTimeException`.