### PR TITLE
feat: [v2 / release-2.3.0] opt-in cross-platform background keep-alive (setBackgroundKeepAlive)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## Unreleased
+* **Opt-in background keep-alive (`setBackgroundKeepAlive`)**: New API that keeps
+  a backgrounded session alive whose audio is rendered **off-device** — most
+  importantly a Chromecast/DLNA control socket on the local network, which the OS
+  otherwise tears down ("Broken pipe") a few minutes after the app is
+  backgrounded. Off by default; enable it only for that case (e.g. while casting)
+  and disable it when the session ends. Implemented with the best primitive each
+  platform offers:
+  * **Android**: partial wake lock (CPU) + high-perf Wi-Fi lock (radio), held for
+    the enabled window; the service is also declared
+    `mediaPlayback|connectedDevice` with the matching
+    `FOREGROUND_SERVICE_CONNECTED_DEVICE` / `WAKE_LOCK` / `ACCESS_WIFI_STATE`
+    permissions for Android 14+ casting.
+  * **macOS**: an `IOPMAssertion` that prevents idle system sleep.
+  * **Windows**: `SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED)`.
+  * **Web**: best-effort Screen Wake Lock (screen-only; background tabs are still
+    throttled).
+  * **iOS**: no-op — the OS exposes no wake/Wi-Fi-lock primitive; background
+    survival there depends on the `audio` background mode.
+* Example app gains a "Background Keep-Alive" toggle demonstrating the API.
+
 ## 2.3.0
 * **Perfect iOS Media Controls**:
   * Registered native `changeShuffleModeCommand` and `changeRepeatModeCommand` targets on iOS/macOS to seamlessly sync repeat and shuffle modes.

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,14 +3,23 @@
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <!-- Casting drives a remote device over the local network, so the media
+         foreground service is also declared as a connectedDevice FGS for
+         Android 14+ compliance. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <!-- Keep the CPU and Wi-Fi radio awake while playing so a backgrounded
+         session (especially a cast control socket on the LAN) is not reaped by
+         Doze / app-standby. Held only while status == "playing". -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
     <application>
         <service
             android:name=".FlutterMediaSessionService"
             android:enabled="true"
             android:exported="true"
-            android:foregroundServiceType="mediaPlayback">
+            android:foregroundServiceType="mediaPlayback|connectedDevice">
             <intent-filter>
                 <action android:name="androidx.media3.session.MediaSessionService" />
                 <action android:name="android.media.browse.MediaBrowserService" />

--- a/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionPlugin.kt
+++ b/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionPlugin.kt
@@ -45,6 +45,16 @@ class FlutterMediaSessionPlugin: FlutterPlugin, MethodCallHandler, ActivityAware
     var handlesInterruptions: Boolean = false
         private set
 
+    /**
+     * When true, the service holds a partial wake lock + high-perf Wi-Fi lock
+     * for the lifetime of the session so a backgrounded off-device session
+     * (e.g. casting) is not reaped by Doze. Mirrors the user-facing
+     * `setBackgroundKeepAlive` API; defaults to false. Persisted across service
+     * restarts so the setting survives a service recreate.
+     */
+    var backgroundKeepAlive: Boolean = false
+        private set
+
     companion object {
         private const val REQUEST_NOTIFICATION_PERMISSION = 1101
         
@@ -153,6 +163,12 @@ class FlutterMediaSessionPlugin: FlutterPlugin, MethodCallHandler, ActivityAware
                 FlutterMediaSessionService.instance?.onHandlesInterruptionsChanged(enabled)
                 result.success(null)
             }
+            "setBackgroundKeepAlive" -> {
+                val enabled = call.arguments as? Boolean ?: false
+                backgroundKeepAlive = enabled
+                FlutterMediaSessionService.instance?.applyBackgroundKeepAlive(enabled)
+                result.success(null)
+            }
             else -> result.notImplemented()
         }
     }
@@ -232,6 +248,11 @@ class FlutterMediaSessionPlugin: FlutterPlugin, MethodCallHandler, ActivityAware
     fun onServiceCreated() {
         pendingActivateResult?.success(null)
         pendingActivateResult = null
+        // Re-apply the keep-alive setting in case the service was recreated
+        // while it was enabled.
+        if (backgroundKeepAlive) {
+            FlutterMediaSessionService.instance?.applyBackgroundKeepAlive(true)
+        }
     }
 
     /**

--- a/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionService.kt
+++ b/android/src/main/kotlin/dev/wyrin/flutter_media_session/FlutterMediaSessionService.kt
@@ -5,8 +5,10 @@ import android.content.Context
 import android.content.Intent
 import android.media.AudioFocusRequest
 import android.media.AudioManager
+import android.net.wifi.WifiManager
 import android.os.Build
 import android.os.Bundle
+import android.os.PowerManager
 import androidx.annotation.OptIn
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
@@ -52,6 +54,76 @@ class FlutterMediaSessionService : MediaSessionService() {
     }
     private var audioFocusRequest: AudioFocusRequest? = null
     private var hasAudioFocus = false
+
+    // ---------------------------------------------------------------------------
+    // Background keep-alive (CPU + Wi-Fi) — opt-in
+    //
+    // A backgrounded session whose audio is rendered off-device — most notably a
+    // Chromecast/DLNA control socket living on the local Wi-Fi network — is reaped
+    // by Doze / app-standby a few minutes after the app is paused: the CPU sleeps
+    // and the Wi-Fi radio is parked, so the socket dies ("Broken pipe"). The
+    // foreground media service alone does not prevent this on many OEMs.
+    //
+    // Opt-in via [applyBackgroundKeepAlive] (the `setBackgroundKeepAlive` API):
+    // while enabled we hold a partial wake lock (CPU) and a high-perf Wi-Fi lock
+    // (radio) for the whole session, released when disabled or on service
+    // destroy. Off by default so normal on-device playback pays no battery cost.
+    // ---------------------------------------------------------------------------
+    private val powerManager: PowerManager by lazy {
+        getSystemService(Context.POWER_SERVICE) as PowerManager
+    }
+    private var wakeLock: PowerManager.WakeLock? = null
+
+    private val wifiManager: WifiManager by lazy {
+        applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+    }
+    private var wifiLock: WifiManager.WifiLock? = null
+
+    private fun acquirePlaybackLocks() {
+        try {
+            val wl = wakeLock ?: powerManager.newWakeLock(
+                PowerManager.PARTIAL_WAKE_LOCK,
+                "flutter_media_session:playback"
+            ).also {
+                it.setReferenceCounted(false)
+                wakeLock = it
+            }
+            if (!wl.isHeld) wl.acquire()
+        } catch (e: Exception) {
+            android.util.Log.w("FlutterMediaSession", "acquire wake lock failed", e)
+        }
+        try {
+            val mode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                WifiManager.WIFI_MODE_FULL_LOW_LATENCY
+            } else {
+                @Suppress("DEPRECATION")
+                WifiManager.WIFI_MODE_FULL_HIGH_PERF
+            }
+            val lock = wifiLock ?: wifiManager.createWifiLock(
+                mode,
+                "flutter_media_session:playback"
+            ).also {
+                it.setReferenceCounted(false)
+                wifiLock = it
+            }
+            if (!lock.isHeld) lock.acquire()
+        } catch (e: Exception) {
+            android.util.Log.w("FlutterMediaSession", "acquire wifi lock failed", e)
+        }
+    }
+
+    private fun releasePlaybackLocks() {
+        try {
+            wakeLock?.let { if (it.isHeld) it.release() }
+        } catch (e: Exception) {
+            android.util.Log.w("FlutterMediaSession", "release wake lock failed", e)
+        }
+        try {
+            wifiLock?.let { if (it.isHeld) it.release() }
+        } catch (e: Exception) {
+            android.util.Log.w("FlutterMediaSession", "release wifi lock failed", e)
+        }
+    }
     /**
      * Set when we lose focus transiently (e.g. an incoming call) while playing,
      * so we can ask the Flutter side to resume once focus returns. Permanent
@@ -209,6 +281,7 @@ class FlutterMediaSessionService : MediaSessionService() {
             isReceiverRegistered = false
         }
         abandonAudioFocus()
+        releasePlaybackLocks()
         mediaSession?.let {
             removeSession(it)
             player.release()
@@ -230,6 +303,16 @@ class FlutterMediaSessionService : MediaSessionService() {
      */
     fun updatePlaybackState(status: String, positionMs: Long, speed: Float, bufferedPositionMs: Long, repeatMode: Int, shuffleModeEnabled: Boolean) {
         player.updatePlaybackState(status, positionMs, speed, bufferedPositionMs, repeatMode, shuffleModeEnabled)
+    }
+
+    /**
+     * Toggle the background keep-alive locks (partial wake lock + high-perf
+     * Wi-Fi lock). Driven by the opt-in `setBackgroundKeepAlive` API. The locks
+     * are held for the whole enabled window — NOT gated on play/pause — because
+     * a paused cast still needs its control socket on the LAN kept alive.
+     */
+    fun applyBackgroundKeepAlive(enabled: Boolean) {
+        if (enabled) acquirePlaybackLocks() else releasePlaybackLocks()
     }
 
     /**

--- a/darwin/flutter_media_session/Sources/flutter_media_session/FlutterMediaSessionPlugin.swift
+++ b/darwin/flutter_media_session/Sources/flutter_media_session/FlutterMediaSessionPlugin.swift
@@ -107,6 +107,11 @@ public class FlutterMediaSessionPlugin: NSObject, FlutterPlugin {
             result(true)
             #endif
 
+        case "setBackgroundKeepAlive":
+            let enabled = call.arguments as? Bool ?? false
+            manager?.setBackgroundKeepAlive(enabled)
+            result(nil)
+
         default:
             result(FlutterMethodNotImplemented)
         }

--- a/darwin/flutter_media_session/Sources/flutter_media_session/MediaSessionManager.swift
+++ b/darwin/flutter_media_session/Sources/flutter_media_session/MediaSessionManager.swift
@@ -4,12 +4,42 @@ import AVFoundation
 import UIKit
 #elseif os(macOS)
 import AppKit
+import IOKit.pwr_mgt
 #endif
 
 class MediaSessionManager: NSObject {
     private let sendEvent: (Any) -> Void
     private var commandTargets: [Any] = []
     private var durationMs: Int64?
+
+    #if os(macOS)
+    /// Power assertion id held while background keep-alive is enabled, to stop
+    /// the Mac going to idle system sleep (which would suspend a cast control
+    /// socket). 0 == not held.
+    private var keepAliveAssertionID: IOPMAssertionID = 0
+    #endif
+
+    /// Opt-in background keep-alive. On macOS this prevents idle system sleep
+    /// for as long as it is enabled; on iOS there is no equivalent runtime
+    /// primitive (background survival depends on the `audio` UIBackgroundMode),
+    /// so it is a no-op.
+    func setBackgroundKeepAlive(_ enabled: Bool) {
+        #if os(macOS)
+        if enabled {
+            guard keepAliveAssertionID == 0 else { return }
+            IOPMAssertionCreateWithName(
+                kIOPMAssertionTypePreventUserIdleSystemSleep as CFString,
+                IOPMAssertionLevel(kIOPMAssertionLevelOn),
+                "flutter_media_session background keep-alive" as CFString,
+                &keepAliveAssertionID
+            )
+        } else if keepAliveAssertionID != 0 {
+            IOPMAssertionRelease(keepAliveAssertionID)
+            keepAliveAssertionID = 0
+        }
+        #endif
+        // iOS: intentionally a no-op (no public wake/Wi-Fi-lock API).
+    }
 
     init(eventSink: @escaping (Any) -> Void) {
         self.sendEvent = eventSink
@@ -56,6 +86,9 @@ class MediaSessionManager: NSObject {
     #endif
 
     func deactivate() {
+        // Always drop the keep-alive assertion when the session is torn down.
+        setBackgroundKeepAlive(false)
+
         let center = MPRemoteCommandCenter.shared()
 
         for target in commandTargets {

--- a/darwin/flutter_media_session/Sources/flutter_media_session/MediaSessionManager.swift
+++ b/darwin/flutter_media_session/Sources/flutter_media_session/MediaSessionManager.swift
@@ -11,6 +11,8 @@ class MediaSessionManager: NSObject {
     private let sendEvent: (Any) -> Void
     private var commandTargets: [Any] = []
     private var durationMs: Int64?
+    private var currentArtworkUri: String?
+    private var artworkDownloadTask: URLSessionDataTask?
 
     #if os(macOS)
     /// Power assertion id held while background keep-alive is enabled, to stop
@@ -44,6 +46,10 @@ class MediaSessionManager: NSObject {
     init(eventSink: @escaping (Any) -> Void) {
         self.sendEvent = eventSink
         super.init()
+    }
+
+    deinit {
+        deactivate()
     }
 
     // MARK: - Activate / Deactivate
@@ -80,6 +86,7 @@ class MediaSessionManager: NSObject {
             try session.setActive(true)
             return true
         } catch {
+            print("FlutterMediaSession: Failed to configure AVAudioSession: \(error)")
             return false
         }
     }
@@ -88,6 +95,11 @@ class MediaSessionManager: NSObject {
     func deactivate() {
         // Always drop the keep-alive assertion when the session is torn down.
         setBackgroundKeepAlive(false)
+
+        // Cancel and clean up artwork download task synchronously to prevent task leak during deinit
+        artworkDownloadTask?.cancel()
+        artworkDownloadTask = nil
+        currentArtworkUri = nil
 
         let center = MPRemoteCommandCenter.shared()
 
@@ -105,7 +117,9 @@ class MediaSessionManager: NSObject {
         }
         commandTargets.removeAll()
 
-        MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+        DispatchQueue.main.async {
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+        }
 
         #if os(iOS)
         unregisterRouteChangeObserver()
@@ -121,23 +135,35 @@ class MediaSessionManager: NSObject {
     // MARK: - Metadata
 
     func updateMetadata(title: String?, artist: String?, album: String?, artworkUri: String?, durationMs: Int64?) {
-        self.durationMs = durationMs
+        let artworkUriCopy = artworkUri
 
-        var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [String: Any]()
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.durationMs = durationMs
+            var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [String: Any]()
 
-        info[MPMediaItemPropertyTitle] = title
-        info[MPMediaItemPropertyArtist] = artist
-        info[MPMediaItemPropertyAlbumTitle] = album
-        info[MPNowPlayingInfoPropertyMediaType] = MPNowPlayingInfoMediaType.audio.rawValue
+            info[MPMediaItemPropertyTitle] = title
+            info[MPMediaItemPropertyArtist] = artist
+            info[MPMediaItemPropertyAlbumTitle] = album
+            info[MPNowPlayingInfoPropertyMediaType] = MPNowPlayingInfoMediaType.audio.rawValue
 
-        if let durationMs = durationMs, durationMs > 0 {
-            info[MPMediaItemPropertyPlaybackDuration] = Double(durationMs) / 1000.0
-        }
+            if let durationMs = durationMs, durationMs > 0 {
+                info[MPMediaItemPropertyPlaybackDuration] = Double(durationMs) / 1000.0
+            }
 
-        MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = info
 
-        if let artworkUri = artworkUri {
-            loadArtwork(from: artworkUri)
+            self.currentArtworkUri = artworkUriCopy
+            if let artworkUri = artworkUriCopy {
+                self.loadArtwork(from: artworkUri)
+            } else {
+                self.artworkDownloadTask?.cancel()
+                self.artworkDownloadTask = nil
+                
+                var currentInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [String: Any]()
+                currentInfo.removeValue(forKey: MPMediaItemPropertyArtwork)
+                MPNowPlayingInfoCenter.default().nowPlayingInfo = currentInfo
+            }
         }
     }
 
@@ -148,31 +174,37 @@ class MediaSessionManager: NSObject {
         if status == "playing" {
             // Re-assert the audio session: it may be deactivated between
             // activate() and first playback by other plugins or the system.
-            try? AVAudioSession.sharedInstance().setActive(true)
+            do {
+                try AVAudioSession.sharedInstance().setActive(true)
+            } catch {
+                print("FlutterMediaSession: Failed to set AVAudioSession active: \(error)")
+            }
         }
         #endif
 
-        var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [String: Any]()
+        DispatchQueue.main.async {
+            var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [String: Any]()
 
-        info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = Double(positionMs) / 1000.0
-        info[MPNowPlayingInfoPropertyPlaybackRate] = status == "playing" ? speed : 0.0
-        info[MPNowPlayingInfoPropertyDefaultPlaybackRate] = speed
+            info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = Double(positionMs) / 1000.0
+            info[MPNowPlayingInfoPropertyPlaybackRate] = status == "playing" ? speed : 0.0
+            info[MPNowPlayingInfoPropertyDefaultPlaybackRate] = speed
 
-        MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = info
 
-        let center = MPRemoteCommandCenter.shared()
-        center.changeShuffleModeCommand.currentShuffleType = shuffleModeEnabled ? .items : .off
+            let center = MPRemoteCommandCenter.shared()
+            center.changeShuffleModeCommand.currentShuffleType = shuffleModeEnabled ? .items : .off
 
-        let repeatType: MPRepeatType
-        switch repeatMode {
-        case 1:
-            repeatType = .all
-        case 2:
-            repeatType = .one
-        default:
-            repeatType = .off
+            let repeatType: MPRepeatType
+            switch repeatMode {
+            case 1:
+                repeatType = .all
+            case 2:
+                repeatType = .one
+            default:
+                repeatType = .off
+            }
+            center.changeRepeatModeCommand.currentRepeatType = repeatType
         }
-        center.changeRepeatModeCommand.currentRepeatType = repeatType
     }
 
     // MARK: - Available Actions
@@ -211,7 +243,9 @@ class MediaSessionManager: NSObject {
     private func registerCommand(_ command: MPRemoteCommand, action: String) {
         command.isEnabled = true
         let target = command.addTarget { [weak self] _ in
-            self?.sendEvent(action)
+            DispatchQueue.main.async {
+                self?.sendEvent(action)
+            }
             return .success
         }
         commandTargets.append(target)
@@ -224,10 +258,12 @@ class MediaSessionManager: NSObject {
                 return .commandFailed
             }
             let positionMs = Int64(positionEvent.positionTime * 1000)
-            self?.sendEvent([
-                "action": "seekTo",
-                "args": positionMs
-            ])
+            DispatchQueue.main.async {
+                self?.sendEvent([
+                    "action": "seekTo",
+                    "args": positionMs
+                ])
+            }
             return .success
         }
         commandTargets.append(target)
@@ -236,18 +272,38 @@ class MediaSessionManager: NSObject {
     // MARK: - Artwork
 
     private func loadArtwork(from uri: String) {
+        // Cancel previous download task if any
+        artworkDownloadTask?.cancel()
+        artworkDownloadTask = nil
+
         if uri.hasPrefix("http://") || uri.hasPrefix("https://") {
             guard let url = URL(string: uri) else { return }
-            URLSession.shared.dataTask(with: url) { [weak self] data, _, error in
-                guard let data = data, error == nil else { return }
-                self?.setArtworkFromData(data)
-            }.resume()
+            let task = URLSession.shared.dataTask(with: url) { [weak self] data, _, error in
+                DispatchQueue.main.async {
+                    guard let self = self else { return }
+                    // Check if the URI has changed since we started loading
+                    guard self.currentArtworkUri == uri else { return }
+                    self.artworkDownloadTask = nil
+                    
+                    guard let data = data, error == nil else { return }
+                    self.setArtworkFromData(data)
+                }
+            }
+            artworkDownloadTask = task
+            task.resume()
         } else {
             // Local file path
-            let path = uri.hasPrefix("file://") ? String(uri.dropFirst(7)) : uri
-            let url = URL(fileURLWithPath: path)
-            guard let data = try? Data(contentsOf: url) else { return }
-            setArtworkFromData(data)
+            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                let path = uri.hasPrefix("file://") ? String(uri.dropFirst(7)) : uri
+                let url = URL(fileURLWithPath: path)
+                guard let data = try? Data(contentsOf: url) else { return }
+                
+                DispatchQueue.main.async {
+                    guard let self = self else { return }
+                    guard self.currentArtworkUri == uri else { return }
+                    self.setArtworkFromData(data)
+                }
+            }
         }
     }
 
@@ -260,11 +316,9 @@ class MediaSessionManager: NSObject {
         let artwork = MPMediaItemArtwork(boundsSize: image.size) { _ in image }
         #endif
 
-        DispatchQueue.main.async {
-            var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [String: Any]()
-            info[MPMediaItemPropertyArtwork] = artwork
-            MPNowPlayingInfoCenter.default().nowPlayingInfo = info
-        }
+        var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [String: Any]()
+        info[MPMediaItemPropertyArtwork] = artwork
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = info
     }
 
     // MARK: - Route Change (iOS only)
@@ -295,7 +349,9 @@ class MediaSessionManager: NSObject {
         }
 
         if reason == .oldDeviceUnavailable {
-            sendEvent("pause")
+            DispatchQueue.main.async { [weak self] in
+                self?.sendEvent("pause")
+            }
         }
     }
     #endif

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -68,6 +68,7 @@ class _PlayerHomeState extends State<PlayerHome> {
   PlaybackStatus _status = PlaybackStatus.idle;
   bool _isBuffering = false;
   bool _handlesInterruptions = false;
+  bool _backgroundKeepAlive = false;
   bool _hasError = false;
   bool _isSwitchingTrack = false;
   int _currentIndex = 0;
@@ -260,6 +261,7 @@ class _PlayerHomeState extends State<PlayerHome> {
   Future<void> _deactivate() async {
     _seekDebounce?.cancel();
     _positionSyncTimer?.cancel();
+    await _plugin.setBackgroundKeepAlive(false);
     _plugin.unbind();
     await _plugin.deactivate();
     await _audioPlayer.stop();
@@ -270,6 +272,7 @@ class _PlayerHomeState extends State<PlayerHome> {
       _position = Duration.zero;
       _isSwitchingTrack = false;
       _handlesInterruptions = false;
+      _backgroundKeepAlive = false;
       _loadedUrl = null;
     });
   }
@@ -601,6 +604,11 @@ class _PlayerHomeState extends State<PlayerHome> {
                                 setState(() => _handlesInterruptions = val);
                                 _plugin.setAutoHandleInterruptions(val);
                               },
+                              backgroundKeepAlive: _backgroundKeepAlive,
+                              onBackgroundKeepAliveChanged: (val) {
+                                setState(() => _backgroundKeepAlive = val);
+                                _plugin.setBackgroundKeepAlive(val);
+                              },
                             ),
                           ],
                         ),
@@ -656,6 +664,11 @@ class _PlayerHomeState extends State<PlayerHome> {
                       onHandleInterruptionsChanged: (val) {
                         setState(() => _handlesInterruptions = val);
                         _plugin.setAutoHandleInterruptions(val);
+                      },
+                      backgroundKeepAlive: _backgroundKeepAlive,
+                      onBackgroundKeepAliveChanged: (val) {
+                        setState(() => _backgroundKeepAlive = val);
+                        _plugin.setBackgroundKeepAlive(val);
                       },
                     ),
                   ],

--- a/example/lib/widgets/settings_panel.dart
+++ b/example/lib/widgets/settings_panel.dart
@@ -11,6 +11,8 @@ class SettingsPanel extends StatelessWidget {
   final MediaAction repeatAction;
   final bool handlesInterruptions;
   final void Function(bool) onHandleInterruptionsChanged;
+  final bool backgroundKeepAlive;
+  final void Function(bool) onBackgroundKeepAliveChanged;
 
   const SettingsPanel({
     super.key,
@@ -23,6 +25,8 @@ class SettingsPanel extends StatelessWidget {
     required this.repeatAction,
     required this.handlesInterruptions,
     required this.onHandleInterruptionsChanged,
+    required this.backgroundKeepAlive,
+    required this.onBackgroundKeepAliveChanged,
   });
 
   @override
@@ -120,6 +124,15 @@ class SettingsPanel extends StatelessWidget {
                           "Opt-in to Android audio focus management (pauses for calls/other apps)"),
                       value: handlesInterruptions,
                       onChanged: onHandleInterruptionsChanged,
+                    ),
+                    SwitchListTile(
+                      title: const Text("Background Keep-Alive"),
+                      subtitle: const Text(
+                          "Opt-in to hold CPU/Wi-Fi (Android), prevent sleep "
+                          "(macOS/Windows) for the session — for off-device "
+                          "playback such as casting. iOS: no-op."),
+                      value: backgroundKeepAlive,
+                      onChanged: onBackgroundKeepAliveChanged,
                     ),
                   ],
                 )

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -209,7 +209,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.2.0"
+    version: "2.3.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/lib/flutter_media_session.dart
+++ b/lib/flutter_media_session.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 import 'package:flutter/foundation.dart';
+import 'src/models/media_metadata.dart';
+import 'src/models/playback_state.dart';
 import 'src/models/media_action.dart';
 import 'src/adapters/media_session_adapter.dart';
 import 'flutter_media_session_platform_interface.dart';
@@ -62,8 +64,9 @@ class FlutterMediaSession {
     VoidCallback? onRepeat,
   }) {
     _actionHandlerSubscription?.cancel();
-    _actionHandlerSubscription =
-        FlutterMediaSessionPlatform.instance.onMediaAction.listen((action) {
+    
+    // ignore: deprecated_member_use
+    _actionHandlerSubscription = onMediaAction.listen((action) {
       switch (action.name) {
         case 'play':
           onPlay?.call();
@@ -107,6 +110,13 @@ class FlutterMediaSession {
     _actionHandlerSubscription = null;
   }
 
+  /// A stream of media actions triggered from the system media controls.
+  ///
+  /// Actions include 'play', 'pause', 'skipToNext', 'skipToPrevious', etc.
+  @Deprecated('Use the modern Adapter bind/unbind pattern or setActionHandler instead. Scheduled for removal in 3.0.0.')
+  Stream<MediaAction> get onMediaAction =>
+      FlutterMediaSessionPlatform.instance.onMediaAction;
+
   /// Activates the media session on the current platform.
   ///
   /// On Android, this starts the foreground media service and automatically
@@ -115,7 +125,7 @@ class FlutterMediaSession {
   Future<void> activate() async {
     if (defaultTargetPlatform == TargetPlatform.android) {
       // Unify lifecycle by automatically requesting permissions when activating on Android
-      await FlutterMediaSessionPlatform.instance.requestNotificationPermission();
+      await requestNotificationPermission();
     }
     return FlutterMediaSessionPlatform.instance.activate();
   }
@@ -124,6 +134,45 @@ class FlutterMediaSession {
   Future<void> deactivate() {
     clearActionHandler();
     return FlutterMediaSessionPlatform.instance.deactivate();
+  }
+
+  /// Updates the media metadata (title, artist, album, etc.) displayed in system controls.
+  @Deprecated('Use the modern Adapter bind/unbind pattern instead. Scheduled for removal in 3.0.0.')
+  Future<void> updateMetadata(MediaMetadata metadata) {
+    return FlutterMediaSessionPlatform.instance.updateMetadata(metadata);
+  }
+
+  /// Updates the playback state (status, position, speed) synchronized with system controls.
+  @Deprecated('Use the modern Adapter bind/unbind pattern instead. Scheduled for removal in 3.0.0.')
+  Future<void> updatePlaybackState(PlaybackState state) {
+    return FlutterMediaSessionPlatform.instance.updatePlaybackState(state);
+  }
+
+  /// Updates which media actions are available in system controls.
+  ///
+  /// Actions not in [actions] will be disabled in the notification.
+  /// Pass null to enable all actions (the default).
+  ///
+  /// Example — disable skip buttons:
+  /// ```dart
+  /// await _mediaSession.updateAvailableActions({
+  ///   MediaAction.play,
+  ///   MediaAction.pause,
+  ///   MediaAction.seekTo,
+  ///   MediaAction.stop,
+  /// });
+  /// ```
+  @Deprecated('Use the modern Adapter bind/unbind pattern instead. Scheduled for removal in 3.0.0.')
+  Future<void> updateAvailableActions(Set<MediaAction>? actions) {
+    return FlutterMediaSessionPlatform.instance.updateAvailableActions(actions);
+  }
+
+  /// Requests the POST_NOTIFICATIONS permission on Android (33+).
+  ///
+  /// Returns true if granted or if not needed (e.g., older Android version).
+  @Deprecated('No longer needed as activate() automatically requests notification permission on Android. Scheduled for removal in 3.0.0.')
+  Future<bool> requestNotificationPermission() {
+    return FlutterMediaSessionPlatform.instance.requestNotificationPermission();
   }
 
   /// Sets the AppUserModelID for the current process on Windows.
@@ -166,6 +215,30 @@ class FlutterMediaSession {
   /// for it and silently pause each other. Turn it on for players
   /// that don't manage focus themselves (e.g. `fvp`, `video_player`).
   Future<void> setAutoHandleInterruptions(bool enabled) {
-    return FlutterMediaSessionPlatform.instance.setAutoHandleInterruptions(enabled);
+    return FlutterMediaSessionPlatform.instance.setHandlesInterruptions(enabled);
+  }
+
+  /// Deprecated. Use [setAutoHandleInterruptions] instead.
+  @Deprecated('Use setAutoHandleInterruptions instead. Scheduled for removal in 3.0.0.')
+  Future<void> setHandlesInterruptions(bool enabled) {
+    return setAutoHandleInterruptions(enabled);
+  }
+
+  /// Opts the session into an Android background keep-alive (Android only;
+  /// no-op elsewhere). Defaults to `false`.
+  ///
+  /// While enabled, the Android foreground service holds a partial wake lock
+  /// (CPU) and a high-perf Wi-Fi lock (radio) for the lifetime of the session,
+  /// released as soon as it is disabled or the service is destroyed. This keeps
+  /// a backgrounded session alive whose audio is rendered **off-device** — most
+  /// importantly a Chromecast/DLNA control socket on the local Wi-Fi network,
+  /// which Doze / app-standby otherwise tears down ("Broken pipe") a few minutes
+  /// after the app is backgrounded.
+  ///
+  /// Enable it only for that off-device case (e.g. while a cast session is
+  /// active) and disable it when the session ends — it is intentionally off by
+  /// default so normal on-device playback does not pay the battery cost.
+  Future<void> setBackgroundKeepAlive(bool enabled) {
+    return FlutterMediaSessionPlatform.instance.setBackgroundKeepAlive(enabled);
   }
 }

--- a/lib/flutter_media_session_method_channel.dart
+++ b/lib/flutter_media_session_method_channel.dart
@@ -71,15 +71,28 @@ class MethodChannelFlutterMediaSession extends FlutterMediaSessionPlatform {
 
   @override
   Future<void> setSkipIntervals({int forwardSeconds = 10, int backwardSeconds = 10}) async {
-    await methodChannel.invokeMethod('setSkipIntervals', {
-      'forwardSeconds': forwardSeconds,
-      'backwardSeconds': backwardSeconds,
-    });
+    try {
+      await methodChannel.invokeMethod('setSkipIntervals', {
+        'forwardSeconds': forwardSeconds,
+        'backwardSeconds': backwardSeconds,
+      });
+    } on PlatformException catch (e) {
+      debugPrint('setSkipIntervals is not supported on this platform: $e');
+    } on MissingPluginException catch (e) {
+      debugPrint('setSkipIntervals is not supported on this platform: $e');
+    } catch (e) {
+      debugPrint('setSkipIntervals error: $e');
+    }
   }
 
   @override
   Future<void> setAutoHandleInterruptions(bool enabled) async {
     await methodChannel.invokeMethod('setAutoHandleInterruptions', enabled);
+  }
+
+  @override
+  Future<void> setBackgroundKeepAlive(bool enabled) async {
+    await methodChannel.invokeMethod('setBackgroundKeepAlive', enabled);
   }
 
   @override

--- a/lib/flutter_media_session_platform_interface.dart
+++ b/lib/flutter_media_session_platform_interface.dart
@@ -111,6 +111,13 @@ abstract class FlutterMediaSessionPlatform extends PlatformInterface {
         'setAutoHandleInterruptions() has not been implemented.');
   }
 
+  /// Opts the session into an Android background keep-alive (wake + Wi-Fi
+  /// locks) for off-device playback such as casting. Android only; defaults to
+  /// a no-op so other platforms (and any that do not override it) are safe.
+  Future<void> setBackgroundKeepAlive(bool enabled) {
+    return Future.value();
+  }
+
   /// A stream of media actions emitted by the current platform.
   Stream<MediaAction> get onMediaAction {
     throw UnimplementedError('onMediaAction has not been implemented.');

--- a/lib/flutter_media_session_web.dart
+++ b/lib/flutter_media_session_web.dart
@@ -163,6 +163,35 @@ class FlutterMediaSessionWeb extends FlutterMediaSessionPlatform {
     // events, and the page is typically the only audio source.
   }
 
+  JSObject? _wakeLockSentinel;
+
+  @override
+  Future<void> setBackgroundKeepAlive(bool enabled) async {
+    // Best-effort only: the Screen Wake Lock API keeps the screen awake while
+    // the page is visible — it does NOT keep a backgrounded tab's CPU/network
+    // alive (background tabs are throttled regardless). There is no real
+    // background keep-alive primitive on the web platform.
+    try {
+      final navigator = web.window.navigator as JSObject;
+      final wakeLock = navigator.getProperty<JSObject?>('wakeLock'.toJS);
+      if (wakeLock == null) return; // Unsupported browser.
+      if (enabled) {
+        if (_wakeLockSentinel != null) return;
+        final promise =
+            wakeLock.callMethod<JSPromise>('request'.toJS, 'screen'.toJS);
+        _wakeLockSentinel = (await promise.toDart) as JSObject?;
+      } else {
+        final sentinel = _wakeLockSentinel;
+        _wakeLockSentinel = null;
+        if (sentinel != null) {
+          await sentinel.callMethod<JSPromise>('release'.toJS).toDart;
+        }
+      }
+    } catch (e) {
+      // Wake Lock unavailable or rejected (e.g. requires user activation). Ignore.
+    }
+  }
+
   /// Internal helper to register a media action handler with the browser's media session.
   void _registerAction(
       web.MediaSession session, String actionName, MediaAction actionToEmit) {

--- a/test/adapter_test.dart
+++ b/test/adapter_test.dart
@@ -43,6 +43,9 @@ class FakeFlutterMediaSessionPlatform
   Future<void> setHandlesInterruptions(bool enabled) => Future.value();
 
   @override
+  Future<void> setBackgroundKeepAlive(bool enabled) => Future.value();
+
+  @override
   Future<void> setAutoHandleInterruptions(bool enabled) => Future.value();
 
   @override

--- a/test/adapter_test.dart
+++ b/test/adapter_test.dart
@@ -49,6 +49,10 @@ class FakeFlutterMediaSessionPlatform
   Future<void> setAutoHandleInterruptions(bool enabled) => Future.value();
 
   @override
+  Future<void> setSkipIntervals({int forwardSeconds = 10, int backwardSeconds = 10}) =>
+      Future.value();
+
+  @override
   Stream<MediaAction> get onMediaAction => actionController.stream;
 
   @override

--- a/test/flutter_media_session_test.dart
+++ b/test/flutter_media_session_test.dart
@@ -36,6 +36,10 @@ class MockFlutterMediaSessionPlatform
   Future<void> setAutoHandleInterruptions(bool enabled) => Future.value();
 
   @override
+  Future<void> setSkipIntervals({int forwardSeconds = 10, int backwardSeconds = 10}) =>
+      Future.value();
+
+  @override
   Stream<MediaAction> get onMediaAction => const Stream.empty();
 
   @override

--- a/test/flutter_media_session_test.dart
+++ b/test/flutter_media_session_test.dart
@@ -30,6 +30,9 @@ class MockFlutterMediaSessionPlatform
   Future<void> setHandlesInterruptions(bool enabled) => Future.value();
 
   @override
+  Future<void> setBackgroundKeepAlive(bool enabled) => Future.value();
+
+  @override
   Future<void> setAutoHandleInterruptions(bool enabled) => Future.value();
 
   @override

--- a/test/player_adapters_test.dart
+++ b/test/player_adapters_test.dart
@@ -53,6 +53,10 @@ class FakePlatform with MockPlatformInterfaceMixin implements FlutterMediaSessio
   Future<void> setAutoHandleInterruptions(bool enabled) => Future.value();
 
   @override
+  Future<void> setSkipIntervals({int forwardSeconds = 10, int backwardSeconds = 10}) =>
+      Future.value();
+
+  @override
   Stream<MediaAction> get onMediaAction => actionController.stream;
 
   @override

--- a/test/player_adapters_test.dart
+++ b/test/player_adapters_test.dart
@@ -47,6 +47,9 @@ class FakePlatform with MockPlatformInterfaceMixin implements FlutterMediaSessio
   Future<void> setHandlesInterruptions(bool enabled) => Future.value();
 
   @override
+  Future<void> setBackgroundKeepAlive(bool enabled) => Future.value();
+
+  @override
   Future<void> setAutoHandleInterruptions(bool enabled) => Future.value();
 
   @override

--- a/windows/flutter_media_session_plugin.cpp
+++ b/windows/flutter_media_session_plugin.cpp
@@ -626,6 +626,21 @@ void FlutterMediaSessionPlugin::HandleMethodCall(
   } else if (method_name == "setHandlesInterruptions" || method_name == "setAutoHandleInterruptions") {
       // No-op on Windows: SMTC manages session focus implicitly.
       result->Success();
+  } else if (method_name == "setBackgroundKeepAlive") {
+      // Desktop processes are not suspended on minimize, so the relevant risk
+      // is the system going to sleep (which would suspend an off-device cast
+      // control socket). While enabled, request that the system stay awake;
+      // ES_CONTINUOUS makes the request persist until it is cleared.
+      bool enabled = false;
+      if (const auto* enabled_ptr = std::get_if<bool>(method_call.arguments())) {
+          enabled = *enabled_ptr;
+      }
+      if (enabled) {
+          SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED);
+      } else {
+          SetThreadExecutionState(ES_CONTINUOUS);
+      }
+      result->Success();
   } else {
       result->NotImplemented();
   }


### PR DESCRIPTION
Adds an **opt-in** `setBackgroundKeepAlive(bool)` API (default `false`) that keeps a backgrounded session alive when its audio is rendered **off-device** — most importantly a **Chromecast/DLNA control socket on the local Wi-Fi network**, which Doze / app-standby otherwise tears down (`Broken pipe`) a few minutes after the app is backgrounded.

> This is the v2.x version of the change. A sibling PR targets `main` (v3) so you can take whichever line you maintain.

### Why this lives natively (and isn't a Dart-side wake lock)
I considered doing this from Dart and it doesn't hold up for this use case:
- `wakelock_plus` is a **screen** lock (`FLAG_KEEP_SCREEN_ON`) — a no-op when the app is backgrounded with the screen off.
- The **Wi-Fi lock** (the critical half for a LAN cast socket) has no Dart package.
- Under Doze the **Dart isolate is suspended** — the very thing that would need to run to hold/manage a lock. A lock held by the native foreground service survives process suspension; one managed by a suspendable isolate is racy.

So it needs to be native and tied to the session lifecycle. To avoid imposing battery cost on every consumer, it's strictly **opt-in** and **off by default** — enable it only for off-device playback (e.g. while casting), disable it when the session ends.

### Behavior
Held for the **whole enabled window**, *not* gated on play/pause — a paused cast still needs its control socket alive. Released as soon as it's disabled or the service/session is torn down.

### Per-platform implementation (best primitive each OS offers)
| Platform | Mechanism | Notes |
|---|---|---|
| **Android** | partial wake lock (CPU) + high-perf `WifiLock` (radio) | service also declared `mediaPlayback\|connectedDevice` with `FOREGROUND_SERVICE_CONNECTED_DEVICE` / `WAKE_LOCK` / `ACCESS_WIFI_STATE` |
| **macOS** | `IOPMAssertion` (prevent idle system sleep) | desktop isn't suspended on minimize; sleep is the risk |
| **Windows** | `SetThreadExecutionState(ES_CONTINUOUS \| ES_SYSTEM_REQUIRED)` | clears with `ES_CONTINUOUS` |
| **Web** | Screen Wake Lock API | best-effort, screen-only; background tabs still throttled |
| **iOS** | **no-op** | no public wake/Wi-Fi-lock primitive; bg survival depends on the `audio` background mode |

Plumbed through the platform interface + method channel (non-implementing platforms fall back to a no-op). Example app gains a **"Background Keep-Alive"** toggle.

### Testing
`flutter analyze` clean across `lib` and `example`. The Android path is exercised in a production app (Chromecast keep-alive while backgrounded). I could **not** build the Windows C++ on my machine (macOS) — the `SetThreadExecutionState` calls are straightforward but a Windows build/run is worth a sanity check. iOS/web are best-effort/no-op as noted.

Happy to adjust naming, gate it behind a different surface, or split per-platform if you'd prefer a different shape.