### PR TITLE
fix(android): apply the Kotlin Android Gradle plugin so the build script compiles

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -3,6 +3,7 @@ version = "1.0-SNAPSHOT"
 
 plugins {
     id("com.android.library")
+    id("org.jetbrains.kotlin.android")
 }
 
 


### PR DESCRIPTION
## Problem

`android/build.gradle.kts` configures Kotlin via:

```kotlin
kotlinOptions {
    jvmTarget = JavaVersion.VERSION_17.toString()
}
```

but its `plugins {}` block only applies `com.android.library`. The `kotlinOptions` DSL accessor is contributed by the Kotlin Android Gradle plugin, which is never applied. On Android Gradle Plugin 8.x with Kotlin Gradle plugin 2.x (a current Flutter app), the build script fails to **compile**:

```
e: .../flutter_media_session/android/build.gradle.kts:19:5: Unresolved reference: kotlinOptions
e: .../flutter_media_session/android/build.gradle.kts:20:9: Unresolved reference: jvmTarget
```

This breaks `assembleDebug` for any consuming app on a modern toolchain (reproduced with Flutter 3.38.3 / AGP 8.12.3 / Kotlin 2.1.0). Both `2.3.0` and `3.0.0-pre.2` are affected, since the accessor can't be provided from outside the package's own build script.

## Fix

Apply `org.jetbrains.kotlin.android` in the plugins block so the `kotlinOptions` accessor exists and the plugin's Kotlin sources compile:

```diff
 plugins {
     id("com.android.library")
+    id("org.jetbrains.kotlin.android")
 }
```

## Verification

Consumed via a `dependency_overrides` git ref, a Flutter app builds a debug APK successfully on the toolchain above (previously failed at script compilation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)